### PR TITLE
Update ltx_video.py

### DIFF
--- a/models/ltx_video.py
+++ b/models/ltx_video.py
@@ -13,7 +13,7 @@ FRAMERATE = 25
 class LTXVideoPipeline(BasePipeline):
     name = 'ltx-video'
     checkpointable_layers = ['TransformerLayer']
-    adapter_target_modules = ['LTXTransformerBlock']
+    adapter_target_modules = ['LTXTransformerBlock', 'LTXVideoTransformerBlock']
 
     def __init__(self, config):
         self.config = config


### PR DESCRIPTION
LTXV apparently changed their module names. Without this small change LTX would not train and instead error out with `ValueError: Target modules set() not found in the base model. Please check the target modules and try again.` because the target modules set was empty (no matches). Probably caused by the recent 0.9.1 update.