### PR TITLE
Added manual partition method for controlling how layers are split be…

### DIFF
--- a/examples/hunyuan_video.toml
+++ b/examples/hunyuan_video.toml
@@ -50,6 +50,8 @@ checkpoint_every_n_minutes = 120
 # Always set to true unless you have a huge amount of VRAM.
 activation_checkpointing = true
 # Controls how Deepspeed decides how to divide layers across GPUs. Probably don't change this.
+# Alternatively you can use 'manual' in combination with partition_split
+#partition_split = [N] # model layers from 0 to N will be loaded to GPU 0 and N to the end will be loaded onto GPU 1
 partition_method = 'parameters'
 # dtype for saving the LoRA or model, if different from training dtype
 save_dtype = 'bfloat16'

--- a/train.py
+++ b/train.py
@@ -26,6 +26,7 @@ from utils.common import is_main_process, get_rank, DTYPE_MAP
 import utils.saver
 from utils.isolate_rng import isolate_rng
 from utils.patches import apply_patches
+from utils.pipeline import ManualPipelineModule
 
 TIMESTEP_QUANTILES_FOR_EVAL = [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9]
 
@@ -420,10 +421,15 @@ if __name__ == '__main__':
             'checkpointable_layers': model.checkpointable_layers,
             'activation_checkpoint_func': checkpoint_func,
         })
-    pipeline_model = deepspeed.pipe.PipelineModule(
+
+    num_stages = config.get('pipeline_stages', 1)
+    partition_method=config.get('partition_method', 'parameters')
+    partition_split = config.get('partition_split',[len(layers) / num_stages])
+    pipeline_model = ManualPipelineModule(
         layers=layers,
-        num_stages=config['pipeline_stages'],
-        partition_method=config.get('partition_method', 'parameters'),
+        num_stages=num_stages,
+        partition_method=partition_method,
+        manual_partition_split=partition_split,
         loss_fn=model.get_loss_fn(),
         **additional_pipeline_module_kwargs
     )

--- a/utils/pipeline.py
+++ b/utils/pipeline.py
@@ -1,0 +1,20 @@
+from deepspeed.pipe import PipelineModule
+
+# PipelineModule partition_method doesn't support uneven partitioning
+# This allow for loading more layers into selected GPU
+# For example if you have 2 gpus - one with 16GB and other with 24GB normal partitioning would throw OOM
+# With this implementation you can set partition_split in config so that less layers is loaded onto 16GB GPU
+class ManualPipelineModule(PipelineModule):
+    def __init__(self, *args, manual_partition_split=None, **kwargs):
+        self.manual_partition_split = manual_partition_split
+        super().__init__(*args, **kwargs)
+
+    def _partition_layers(self, method='uniform'):
+        if method.lower() == 'manual' and self.manual_partition_split is not None:
+            total_layers = len(self._layer_specs)
+            boundaries = [0] + self.manual_partition_split + [total_layers]
+            stage_id = self._topo.get_coord(self.global_rank).pipe
+            self.parts = boundaries
+            self._set_bounds(start=self.parts[stage_id], stop=self.parts[stage_id+1])
+        else:
+            super()._partition_layers(method)


### PR DESCRIPTION
I'm running lora training with it right now with Wan2.1 14b on 16GB and 24GB gpus. 
```
partition_method = 'manual'
partition_split = [15]
```
This result with one gpu using 14GB out of 16GB and other 23GB out of 24GB during training.
With standard
```
partition_method = 'parameters'
````
I'm getting OOM on 16GB gpu.