### PR TITLE
Cache multiple shuffled captions

### DIFF
--- a/examples/dataset.toml
+++ b/examples/dataset.toml
@@ -37,6 +37,11 @@ frame_buckets = [1, 33]
 # If you have >24GB VRAM, or multiple GPUs and use pipeline parallelism, or lower the spatial resolution, you could maybe train with longer frame buckets
 # frame_buckets = [1, 33, 65, 97]
 
+# Shuffle tags before caching, 0 to keep original caption. Increases caching time a little bit, does not affect training time.
+# cache_shuffle_num = 10
+# Delimiter for tags, only used if cache_shuffle_num is not 0. Defaults to ", ".
+# "tag1, tag2, tag3" has ", " as delimiter and will possibly be shuffled like "tag3, tag1, tag2". "tag1;tag2;tag3" has ";" as delimiter and will possibly be shuffled like "tag2;tag1;tag3".
+# cache_shuffle_delimiter = ", "
 
 [[directory]]
 # Path to directory of images/videos, and corresponding caption files. The caption files should match the media file name, but with a .txt extension.

--- a/examples/dataset.toml
+++ b/examples/dataset.toml
@@ -37,7 +37,7 @@ frame_buckets = [1, 33]
 # If you have >24GB VRAM, or multiple GPUs and use pipeline parallelism, or lower the spatial resolution, you could maybe train with longer frame buckets
 # frame_buckets = [1, 33, 65, 97]
 
-# Shuffle tags before caching, 0 to keep original caption. Increases caching time a little bit, does not affect training time.
+# Shuffle tags before caching, 0 to keep original caption (unless shuffle_tags is set to true). Increases caching time a tiny bit for higher values.
 # cache_shuffle_num = 10
 # Delimiter for tags, only used if cache_shuffle_num is not 0. Defaults to ", ".
 # "tag1, tag2, tag3" has ", " as delimiter and will possibly be shuffled like "tag3, tag1, tag2". "tag1;tag2;tag3" has ";" as delimiter and will possibly be shuffled like "tag2;tag1;tag3".

--- a/utils/dataset.py
+++ b/utils/dataset.py
@@ -40,7 +40,7 @@ def shuffle_captions(captions: list[str], count: int = 0, delimiter: str = ', ',
         random.shuffle(split)
         return delimiter.join(split)
 
-    return [caption_prefix + shuffle_caption(caption, delimiter) for _ in range(count) for caption in captions]
+    return [caption_prefix + shuffle_caption(caption, delimiter) for caption in captions for _ in range(count)]
 
 
 def process_caption_fn(shuffle_tags=False, caption_prefix=''):

--- a/utils/dataset.py
+++ b/utils/dataset.py
@@ -442,7 +442,7 @@ class DirectoryDataset:
                 logger.warning(f'Cound not find caption for {image_file}. Using empty caption.')
             if self.directory_config['shuffle_tags'] and self.shuffle == 0: # backwards compatibility
                 self.shuffle = 1
-            captions = shuffle_captions(captions, self.shuffle, self.shuffle_delimiter)
+            captions = shuffle_captions(captions, self.shuffle, self.shuffle_delimiter, self.directory_config['caption_prefix'])
             empty_return = {'image_file': [], 'mask_file': [], 'caption': [], 'ar_bucket': [], 'size_bucket': [], 'is_video': []}
 
             image_file = Path(image_file)

--- a/utils/dataset.py
+++ b/utils/dataset.py
@@ -174,10 +174,11 @@ class SizeBucketDataset:
         ret = self.latent_dataset[self.image_file_to_latents_idx[image_file]]
         if DEBUG:
             print(Path(image_file).stem)
+        offset = random.randrange(self.shuffle_skip)
+        caption_idx = (caption_number*self.shuffle_skip) + offset
         for ds in self.text_embedding_datasets:
-            offset = random.randrange(self.shuffle_skip)
-            ret.update(ds.get_text_embeddings(image_file, (caption_number*self.shuffle_skip) + offset))
-        ret['caption'] = caption
+            ret.update(ds.get_text_embeddings(image_file, caption_idx))
+        ret['caption'] = caption[caption_idx]
         return ret
 
     def __len__(self):


### PR DESCRIPTION
## In this PR
This PR adds 2 new dataset config flags.
`cache_shuffle_num` - Setting this to for example `10` will make 10 shuffled variations of the caption. Effectively as if you had multiple captions. Setting this to 0 disables shuffling and setting it to 1 behaves like the `shuffle_tags` value.
`cache_shuffle_delimiter` - Allows for using custom delimiters for shuffling, defaults to ", " for comma separated tags.

This PR is a workaround for issues like #92, by shuffling multiple captions beforehand there's no need to re-cache, while still providing better variety from the shuffling.

`SizeBucketDataset`'s `cache_latents` function splits the shuffled variations, when one is selected in `__getitem__`, an offset is picked at random, this offset determines the shuffle variation. It then gets the caption by the index `(caption_number*self.shuffle_skip) + offset`. Caption number is the original caption number, offset is the randomly determined offset. I did it this way because I wanted to change existing things as little as possible.

## Backwards compatibilty
To ensure backwards compatibility I changed `shuffle_tags` to set `cache_shuffle_num` to 1 if it wasn't set to something else yet.

## Testing
Tested locally on wsl. Caching with `cache_shuffle_num` set to 42 on a dataset with 1 caption caches 42 shuffled captions as expected.
Training was also tested to ensure that only one value is picked from the shuffled options. Meaning the amount of shuffles does not affect the epoch step count.