### PR TITLE
fix new transformer vesion error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 deepspeed
 toml
-transformers
+transformers==4.51.3
 diffusers>=0.32.1
 datasets
 pillow


### PR DESCRIPTION
transformer lib update and it will has some error
https://pypi.org/project/transformers/#history

NameError: name 'Replicate' is not defined

transformer lib fixed to pre version.