### PR TITLE
Fix wandb monitoring being started separately for all processes

### DIFF
--- a/train.py
+++ b/train.py
@@ -465,7 +465,7 @@ if __name__ == '__main__':
 
     # WandB logging
     wandb_enable = config.get('monitoring', {}).get('enable_wandb', False)
-    if wandb_enable:
+    if wandb_enable and is_main_process():
         wandb_api_key     = config['monitoring']['wandb_api_key']
         wandb_tracker     = config['monitoring']['wandb_tracker_name']
         wandb_run_name    = config['monitoring']['wandb_run_name']


### PR DESCRIPTION
When training with multiple GPUs, wandb monitoring was started for all processes, leading to multiple runs being logged into wandb, one for each process/GPU. This is fixed by only starting the monitoring for the main process.

The logging itself already contains this check, so no changes are needed there. Because of the existing check, the training stats were only logged into the main wandb run before, but the other runs on wandb still contained system stats such as memory consumption etc.