### PR TITLE
Patch to requirements.txt to include missing depedency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -26,4 +26,4 @@ easydict
 ftfy
 pytorch-optimizer
 wandb
-optimum
+optimum-quanto


### PR DESCRIPTION
Seems like requirements.txt was missing `optimum-quanto` for automagic. Included it here which solves the issue.

```
pip install -r requirements.txt
```