### PR TITLE
Add ProdigyPlusScheduleFree optimizer

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -28,3 +28,4 @@ wandb
 optimum-quanto
 wheel
 ninja
+prodigy-plus-schedule-free


### PR DESCRIPTION
This adds support for the experimental [ProdigyPlusScheduleFree](https://github.com/LoganBooker/prodigy-plus-schedule-free) optimiser.

From the Schedule-Free [docs](https://github.com/facebookresearch/schedule_free?tab=readme-ov-file#how-to-use), `optimizer.eval()` / `optimizer.train()` calls are done before training/eval/saving.

Here's a reasonably smooth validation graph showing it in action:

<img width="3160" height="1660" alt="W B Chart" src="https://github.com/user-attachments/assets/4c05d59f-3e16-4ca2-8aa5-c37a2a68d8aa" />

Closes #427