### PR TITLE
Fix: Disable comfy-kitchen in training to prevent autograd crash

### DIFF
--- a/train.py
+++ b/train.py
@@ -1,6 +1,9 @@
 import argparse
 import os
 import wandb
+# Disable comfy_kitchen during training to avoid autograd errors
+import sys
+sys.modules["comfy_kitchen"] = None
 from datetime import datetime, timezone
 import shutil
 import glob


### PR DESCRIPTION
Description: When comfy-kitchen is installed in the environment, ComfyUI automatically uses its optimized kernels (e.g., apply_rope). However, these kernels are optimized for inference and do not implement a backward pass, forcing loss.backward() to fail with a RuntimeError.
﻿
Fix: This PR explictly disables comfy-kitchen within train.py by mocking it in sys.modules. This forces the codebase to fall back to the native PyTorch/Python implementations which support autograd, ensuring training works correctly without requiring users to uninstall the acceleration library.