### PR TITLE
Support Anima model

### DIFF
--- a/models/anima.py
+++ b/models/anima.py
@@ -1,0 +1,539 @@
+# Anima Pipeline for diffusion-pipe
+# Based on Cosmos-Predict2 but with dual text encoders (Qwen3-0.6B + T5)
+# Uses Qwen Image VAE (same architecture/normalization as Wan VAE)
+
+import math
+import random
+
+import torch
+from torch import nn
+import torch.nn.functional as F
+import safetensors
+import transformers
+from transformers import T5TokenizerFast, AutoTokenizer, AutoModelForCausalLM, AutoConfig
+from accelerate import init_empty_weights
+from accelerate.utils import set_module_tensor_to_device
+
+from models.base import BasePipeline, PreprocessMediaFile, make_contiguous
+from models.anima_modeling import Anima
+from models.cosmos_predict2 import get_dit_config, time_shift, get_lin_function, WanVAE, vae_encode
+from utils.common import load_state_dict, AUTOCAST_DTYPE
+from utils.offloading import ModelOffloader
+
+
+KEEP_IN_HIGH_PRECISION = ['x_embedder', 't_embedder', 't_embedding_norm', 'final_layer', 'llm_adapter']
+
+
+def _shuffle_tags(caption, delimiter=', ', keep_first_n=0):
+    """
+    Shuffle tags in a caption string at training time.
+
+    Args:
+        caption: Caption string with tags separated by delimiter
+        delimiter: Tag separator (default ", " for danbooru-style tags)
+        keep_first_n: Keep the first N tags in place, shuffle the rest
+                     (useful for keeping trigger words at the start)
+
+    Returns:
+        Caption with tags shuffled
+    """
+    if not caption or delimiter not in caption:
+        return caption
+
+    tags = caption.split(delimiter)
+    if len(tags) <= 1:
+        return caption
+
+    # Keep first N tags in place, shuffle the rest
+    if keep_first_n > 0 and keep_first_n < len(tags):
+        prefix = tags[:keep_first_n]
+        suffix = tags[keep_first_n:]
+        random.shuffle(suffix)
+        tags = prefix + suffix
+    else:
+        random.shuffle(tags)
+
+    return delimiter.join(tags)
+
+
+def _tokenize_t5(tokenizer, prompts):
+    """Tokenize prompts using T5 tokenizer."""
+    return tokenizer(
+        prompts,
+        return_tensors="pt",
+        truncation=True,
+        padding="max_length",
+        max_length=512,
+    )
+
+
+def _tokenize_qwen(tokenizer, prompts):
+    """Tokenize prompts using Qwen tokenizer."""
+    return tokenizer(
+        prompts,
+        return_tensors="pt",
+        truncation=True,
+        padding="max_length",
+        max_length=512,
+    )
+
+
+def _compute_qwen_embeddings(qwen_model, input_ids, attention_mask):
+    """Compute Qwen3 hidden states for use as cross-attention context."""
+    if attention_mask is None:
+        attention_mask = torch.ones_like(input_ids)
+    input_ids = input_ids.to(qwen_model.device, dtype=torch.long)
+    attention_mask = attention_mask.to(qwen_model.device, dtype=torch.long)
+
+    with torch.no_grad():
+        outputs = qwen_model(
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            output_hidden_states=True,
+            return_dict=True,
+        )
+
+    # Use the last hidden state
+    hidden_states = outputs.hidden_states[-1]
+
+    # Zero out padding positions
+    lengths = attention_mask.sum(dim=1).cpu()
+    for batch_id in range(hidden_states.shape[0]):
+        length = lengths[batch_id]
+        if length == 1:  # Empty prompt case
+            length = 0
+        hidden_states[batch_id][length:] = 0
+
+    return hidden_states
+
+
+class AnimaPipeline(BasePipeline):
+    name = 'anima'
+    framerate = 16
+    checkpointable_layers = ['TransformerLayer']
+    adapter_target_modules = ['Block', 'LLMAdapterTransformerBlock']
+
+    def __init__(self, config):
+        self.config = config
+        self.model_config = self.config['model']
+        # Determine if we're doing LoRA or full-finetune based on presence of adapter config
+        self.is_adapter = 'adapter' in config
+        # For full-finetune, skip_lora should be False (swap all weights including what would be LoRA)
+        self.skip_lora = self.is_adapter
+        self.offloader = ModelOffloader('dummy', [], 0, 0, True, torch.device('cuda'), False, debug=False, skip_lora=self.skip_lora)
+        dtype = self.model_config['dtype']
+        self.cache_text_embeddings = self.model_config.get('cache_text_embeddings', True)
+
+        # Full-finetune specific options
+        self.freeze_llm_adapter = self.model_config.get('freeze_llm_adapter', False)
+        self.llm_adapter_lr = self.model_config.get('llm_adapter_lr', None)
+
+        # Load transformer directly to CUDA (faster init, single GPU only)
+        self.load_to_cuda = self.model_config.get('load_to_cuda', False)
+
+        # Training-time tag shuffling (only works when cache_text_embeddings=false)
+        self.shuffle_tags = self.model_config.get('shuffle_tags', False)
+        self.tag_delimiter = self.model_config.get('tag_delimiter', ', ')
+        self.keep_first_n_tags = self.model_config.get('keep_first_n_tags', 0)
+        if self.shuffle_tags and self.cache_text_embeddings:
+            print("WARNING: shuffle_tags requires cache_text_embeddings=false to work at training time. "
+                  "With cache_text_embeddings=true, use cache_shuffle_num in your dataset config instead.")
+
+        # VAE - Qwen Image VAE (16 channel, same architecture/normalization as Wan VAE)
+        self.vae = WanVAE(
+            vae_pth=self.model_config['vae_path'],
+            dtype=dtype,
+        )
+        self.vae.mean = self.vae.mean.to('cuda')
+        self.vae.std = self.vae.std.to('cuda')
+        self.vae.scale = [self.vae.mean, 1.0 / self.vae.std]
+
+        # T5 Tokenizer - for getting token IDs (used by LLMAdapter)
+        self.t5_tokenizer = T5TokenizerFast(
+            vocab_file='configs/t5_old/spiece.model',
+            tokenizer_file='configs/t5_old/tokenizer.json',
+        )
+
+        # Qwen3 Tokenizer and Model - for getting embeddings
+        qwen_path = self.model_config['qwen_path']
+        self.qwen_tokenizer = AutoTokenizer.from_pretrained(
+            qwen_path,
+            trust_remote_code=True,
+            local_files_only=True,
+        )
+        if self.qwen_tokenizer.pad_token is None:
+            self.qwen_tokenizer.pad_token = self.qwen_tokenizer.eos_token
+
+        # Load Qwen3-0.6B model for text encoding
+        qwen_config = AutoConfig.from_pretrained(qwen_path, trust_remote_code=True, local_files_only=True)
+
+        if self.model_config.get('qwen_nf4', False):
+            quantization_config = transformers.BitsAndBytesConfig(
+                load_in_4bit=True,
+                bnb_4bit_quant_type='nf4',
+                bnb_4bit_compute_dtype=dtype,
+            )
+        else:
+            quantization_config = None
+
+        self.qwen_model = AutoModelForCausalLM.from_pretrained(
+            qwen_path,
+            config=qwen_config,
+            torch_dtype=dtype,
+            local_files_only=True,
+            quantization_config=quantization_config,
+            trust_remote_code=True,
+        )
+
+        if quantization_config is None and self.model_config.get('qwen_fp8', False):
+            for name, p in self.qwen_model.named_parameters():
+                if p.ndim == 2:
+                    p.data = p.data.to(torch.float8_e4m3fn)
+
+        self.qwen_model.requires_grad_(False)
+
+    def load_diffusion_model(self):
+        dtype = self.model_config['dtype']
+        transformer_dtype = self.model_config.get('transformer_dtype', dtype)
+
+        # Determine target device for loading
+        target_device = 'cuda' if self.load_to_cuda else 'cpu'
+        if self.load_to_cuda:
+            print(f"Loading transformer directly to CUDA (faster initialization)")
+
+        state_dict = load_state_dict(self.model_config['transformer_path'])
+
+        # Remove 'net.' prefix if present
+        new_state_dict = {}
+        for k, v in state_dict.items():
+            if k.startswith('net.'):
+                k = k[len('net.'):]
+            # Handle ComfyUI format with 'diffusion_model.' prefix
+            if k.startswith('diffusion_model.'):
+                k = k[len('diffusion_model.'):]
+            new_state_dict[k] = v
+        state_dict = new_state_dict
+
+        # Get config for base model (without llm_adapter weights)
+        base_state_dict = {k: v for k, v in state_dict.items() if not k.startswith('llm_adapter.')}
+        dit_config = get_dit_config(base_state_dict)
+
+        with init_empty_weights():
+            transformer = Anima(**dit_config)
+
+        for name, p in transformer.named_parameters():
+            # Keep LLMAdapter and certain layers in higher precision
+            dtype_to_use = dtype if (any(keyword in name for keyword in KEEP_IN_HIGH_PRECISION) or p.ndim == 1) else transformer_dtype
+            if name in state_dict:
+                set_module_tensor_to_device(transformer, name, device=target_device, dtype=dtype_to_use, value=state_dict[name])
+            else:
+                # Initialize missing weights (shouldn't happen with proper checkpoint)
+                print(f"Warning: Missing weight {name}, initializing randomly")
+                set_module_tensor_to_device(transformer, name, device=target_device, dtype=dtype_to_use, value=torch.randn_like(p))
+
+        self.transformer = transformer
+        self.transformer.train()
+
+        # Handle LLMAdapter freezing for full-finetune
+        if self.freeze_llm_adapter:
+            for name, p in self.transformer.llm_adapter.named_parameters():
+                p.requires_grad_(False)
+            print("LLMAdapter is frozen for training")
+
+        for name, p in self.transformer.named_parameters():
+            p.original_name = name
+
+    def get_param_groups(self, parameters):
+        """
+        Support separate learning rate for LLMAdapter vs DiT.
+        Override from BasePipeline.
+        """
+        if self.llm_adapter_lr is None:
+            # Default behavior: single param group (same LR for all)
+            return [{'params': parameters}]
+
+        # Separate param groups for different LRs
+        llm_adapter_params = []
+        dit_params = []
+
+        for p in parameters:
+            if hasattr(p, 'original_name') and 'llm_adapter' in p.original_name:
+                llm_adapter_params.append(p)
+            else:
+                dit_params.append(p)
+
+        param_groups = []
+        if dit_params:
+            param_groups.append({'params': dit_params})  # Uses default LR from config
+        if llm_adapter_params:
+            param_groups.append({'params': llm_adapter_params, 'lr': self.llm_adapter_lr})
+            print(f"Using separate LR for LLMAdapter: {self.llm_adapter_lr}")
+
+        return param_groups
+
+    def get_vae(self):
+        return self.vae.model
+
+    def get_text_encoders(self):
+        if self.cache_text_embeddings:
+            return [self.qwen_model]
+        else:
+            return []
+
+    def save_adapter(self, save_dir, peft_state_dict):
+        self.peft_config.save_pretrained(save_dir)
+        # ComfyUI format
+        peft_state_dict = {'diffusion_model.'+k: v for k, v in peft_state_dict.items()}
+        safetensors.torch.save_file(peft_state_dict, save_dir / 'adapter_model.safetensors', metadata={'format': 'pt'})
+
+    def save_model(self, save_dir, state_dict):
+        state_dict = {'net.'+k: v for k, v in state_dict.items()}
+        safetensors.torch.save_file(state_dict, save_dir / 'model.safetensors', metadata={'format': 'pt'})
+
+    def get_preprocess_media_file_fn(self):
+        return PreprocessMediaFile(
+            self.config,
+            support_video=True,
+            framerate=self.framerate,
+        )
+
+    def get_call_vae_fn(self, vae):
+        def fn(tensor):
+            p = next(vae.parameters())
+            tensor = tensor.to(p.device, p.dtype)
+            latents = vae_encode(tensor, self.vae)
+            return {'latents': latents}
+        return fn
+
+    def get_call_text_encoder_fn(self, text_encoder):
+        """
+        Returns a function that computes both:
+        - Qwen3 embeddings (for LLMAdapter cross-attention context)
+        - T5 token IDs (for LLMAdapter embedding input)
+        """
+        def fn(captions, is_video):
+            # Get Qwen3 embeddings
+            qwen_encoding = _tokenize_qwen(self.qwen_tokenizer, captions)
+            qwen_embeds = _compute_qwen_embeddings(
+                self.qwen_model,
+                qwen_encoding.input_ids,
+                qwen_encoding.attention_mask
+            )
+
+            # Get T5 token IDs
+            t5_encoding = _tokenize_t5(self.t5_tokenizer, captions)
+
+            return {
+                'qwen_embeds': qwen_embeds,
+                't5_input_ids': t5_encoding.input_ids,
+                't5_attention_mask': t5_encoding.attention_mask,
+            }
+        return fn
+
+    def prepare_inputs(self, inputs, timestep_quantile=None):
+        latents = inputs['latents'].float()
+        mask = inputs['mask']
+
+        if self.cache_text_embeddings:
+            qwen_inputs = (inputs['qwen_embeds'],)
+            t5_input_ids = inputs['t5_input_ids']
+        else:
+            # Compute on-the-fly
+            captions = inputs['caption']
+
+            # Apply training-time tag shuffling if enabled
+            if self.shuffle_tags:
+                if isinstance(captions, list):
+                    captions = [_shuffle_tags(c, self.tag_delimiter, self.keep_first_n_tags) for c in captions]
+                else:
+                    captions = _shuffle_tags(captions, self.tag_delimiter, self.keep_first_n_tags)
+
+            qwen_encoding = _tokenize_qwen(self.qwen_tokenizer, captions)
+            qwen_inputs = (qwen_encoding.input_ids, qwen_encoding.attention_mask)
+            t5_encoding = _tokenize_t5(self.t5_tokenizer, captions)
+            t5_input_ids = t5_encoding.input_ids
+
+        bs, channels, num_frames, h, w = latents.shape
+
+        if mask is not None:
+            mask = mask.unsqueeze(1)  # make mask (bs, 1, img_h, img_w)
+            mask = F.interpolate(mask, size=(h, w), mode='nearest-exact')  # resize to latent spatial dimension
+            mask = mask.unsqueeze(2)  # make mask same number of dims as target
+
+        timestep_sample_method = self.model_config.get('timestep_sample_method', 'logit_normal')
+
+        if timestep_sample_method == 'logit_normal':
+            dist = torch.distributions.normal.Normal(0, 1)
+        elif timestep_sample_method == 'uniform':
+            dist = torch.distributions.uniform.Uniform(0, 1)
+        else:
+            raise NotImplementedError()
+
+        if timestep_quantile is not None:
+            t = dist.icdf(torch.full((bs,), timestep_quantile, device=latents.device))
+        else:
+            t = dist.sample((bs,)).to(latents.device)
+
+        if timestep_sample_method == 'logit_normal':
+            sigmoid_scale = self.model_config.get('sigmoid_scale', 1.0)
+            t = t * sigmoid_scale
+            t = torch.sigmoid(t)
+
+        if shift := self.model_config.get('shift', None):
+            t = (t * shift) / (1 + (shift - 1) * t)
+        elif self.model_config.get('flux_shift', False):
+            mu = get_lin_function(y1=0.5, y2=1.15)((h // 2) * (w // 2))
+            t = time_shift(mu, 1.0, t)
+
+        noise = torch.randn_like(latents)
+        t_expanded = t.view(-1, 1, 1, 1, 1)
+        noisy_latents = (1 - t_expanded)*latents + t_expanded*noise
+        target = noise - latents
+
+        return (noisy_latents, t.view(-1, 1), *qwen_inputs, t5_input_ids), (target, mask)
+
+    def to_layers(self):
+        transformer = self.transformer
+        qwen_model = None if self.cache_text_embeddings else self.qwen_model
+        layers = [InitialLayer(transformer, qwen_model, self.qwen_tokenizer, self.t5_tokenizer)]
+        for i, block in enumerate(transformer.blocks):
+            layers.append(TransformerLayer(block, i, self.offloader))
+        layers.append(FinalLayer(transformer))
+        return layers
+
+    def enable_block_swap(self, blocks_to_swap):
+        transformer = self.transformer
+        blocks = transformer.blocks
+        num_blocks = len(blocks)
+        assert (
+            blocks_to_swap <= num_blocks - 2
+        ), f'Cannot swap more than {num_blocks - 2} blocks. Requested {blocks_to_swap} blocks to swap.'
+        self.offloader = ModelOffloader(
+            'TransformerBlock', blocks, num_blocks, blocks_to_swap, True, torch.device('cuda'),
+            self.config['reentrant_activation_checkpointing'], skip_lora=self.skip_lora
+        )
+        transformer.blocks = None
+        transformer.to('cuda')
+        transformer.blocks = blocks
+        self.prepare_block_swap_training()
+        print(f'Block swap enabled. Swapping {blocks_to_swap} blocks out of {num_blocks} blocks.')
+        if not self.skip_lora:
+            print('Full-finetune mode: all weights will be swapped (skip_lora=False)')
+
+    def prepare_block_swap_training(self):
+        self.offloader.enable_block_swap()
+        self.offloader.set_forward_only(False)
+        self.offloader.prepare_block_devices_before_forward()
+
+    def prepare_block_swap_inference(self, disable_block_swap=False):
+        if disable_block_swap:
+            self.offloader.disable_block_swap()
+        self.offloader.set_forward_only(True)
+        self.offloader.prepare_block_devices_before_forward()
+
+
+class InitialLayer(nn.Module):
+    def __init__(self, model, qwen_model, qwen_tokenizer, t5_tokenizer):
+        super().__init__()
+        self.x_embedder = model.x_embedder
+        self.pos_embedder = model.pos_embedder
+        if model.extra_per_block_abs_pos_emb:
+            self.extra_pos_embedder = model.extra_pos_embedder
+        self.t_embedder = model.t_embedder
+        self.t_embedding_norm = model.t_embedding_norm
+        self.llm_adapter = model.llm_adapter
+        self.qwen_model = qwen_model
+        self.qwen_tokenizer = qwen_tokenizer
+        self.t5_tokenizer = t5_tokenizer
+        self.model = [model]
+
+    @torch.autocast('cuda', dtype=AUTOCAST_DTYPE)
+    def forward(self, inputs):
+        x_B_C_T_H_W, timesteps_B_T, *text_inputs = inputs
+
+        # If qwen_model is not None, we need to compute embeddings on-the-fly.
+        # In cached mode, qwen_embeds is already computed and passed through.
+        if self.qwen_model is None:
+            assert len(text_inputs) == 2, f"Expected cached inputs (qwen_embeds, t5_input_ids), got {len(text_inputs)} items."
+            qwen_embeds, t5_input_ids = text_inputs
+        else:
+            assert len(text_inputs) == 3, f"Expected non-cached inputs (qwen_input_ids, qwen_attention_mask, t5_input_ids), got {len(text_inputs)} items."
+            qwen_input_ids, qwen_attention_mask, t5_input_ids = text_inputs
+            with torch.no_grad():
+                qwen_embeds = _compute_qwen_embeddings(
+                    self.qwen_model,
+                    qwen_input_ids,
+                    qwen_attention_mask,
+                )
+
+        target_device = x_B_C_T_H_W.device
+        if qwen_embeds.device != target_device:
+            qwen_embeds = qwen_embeds.to(target_device)
+        if t5_input_ids.device != target_device:
+            t5_input_ids = t5_input_ids.to(target_device)
+        if t5_input_ids.dtype != torch.long:
+            t5_input_ids = t5_input_ids.long()
+
+        # Process through LLM adapter to get final cross-attention embeddings
+        crossattn_emb = self.llm_adapter(qwen_embeds, t5_input_ids)
+
+        # Pad to 512 tokens if needed
+        if crossattn_emb.shape[1] < 512:
+            crossattn_emb = F.pad(crossattn_emb, (0, 0, 0, 512 - crossattn_emb.shape[1]))
+
+        padding_mask = torch.zeros(x_B_C_T_H_W.shape[0], 1, x_B_C_T_H_W.shape[3], x_B_C_T_H_W.shape[4], dtype=x_B_C_T_H_W.dtype, device=x_B_C_T_H_W.device)
+        x_B_T_H_W_D, rope_emb_L_1_1_D, extra_pos_emb_B_T_H_W_D_or_T_H_W_B_D = self.model[0].prepare_embedded_sequence(
+            x_B_C_T_H_W,
+            fps=None,
+            padding_mask=padding_mask,
+        )
+        assert extra_pos_emb_B_T_H_W_D_or_T_H_W_B_D is None
+        assert rope_emb_L_1_1_D is not None
+
+        if timesteps_B_T.ndim == 1:
+            timesteps_B_T = timesteps_B_T.unsqueeze(1)
+        t_embedding_B_T_D, adaln_lora_B_T_3D = self.t_embedder(timesteps_B_T)
+        t_embedding_B_T_D = self.t_embedding_norm(t_embedding_B_T_D)
+
+        outputs = make_contiguous(x_B_T_H_W_D, t_embedding_B_T_D, crossattn_emb, rope_emb_L_1_1_D, adaln_lora_B_T_3D, timesteps_B_T)
+        for item in outputs:
+            item.requires_grad_(True)
+        return outputs
+
+
+class TransformerLayer(nn.Module):
+    def __init__(self, block, block_idx, offloader):
+        super().__init__()
+        self.block = block
+        self.block_idx = block_idx
+        self.offloader = offloader
+
+    @torch.autocast('cuda', dtype=AUTOCAST_DTYPE)
+    def forward(self, inputs):
+        x_B_T_H_W_D, t_embedding_B_T_D, crossattn_emb, rope_emb_L_1_1_D, adaln_lora_B_T_3D, timesteps_B_T = inputs
+
+        self.offloader.wait_for_block(self.block_idx)
+        x_B_T_H_W_D = self.block(x_B_T_H_W_D, t_embedding_B_T_D, crossattn_emb, rope_emb_L_1_1_D=rope_emb_L_1_1_D, adaln_lora_B_T_3D=adaln_lora_B_T_3D)
+        self.offloader.submit_move_blocks_forward(self.block_idx)
+
+        return make_contiguous(x_B_T_H_W_D, t_embedding_B_T_D, crossattn_emb, rope_emb_L_1_1_D, adaln_lora_B_T_3D, timesteps_B_T)
+
+
+class FinalLayer(nn.Module):
+    def __init__(self, model):
+        super().__init__()
+        self.final_layer = model.final_layer
+        self.model = [model]
+
+    def __getattr__(self, name):
+        return getattr(self.model[0], name)
+
+    def get_per_sigma_loss_weights(self, sigma: torch.Tensor) -> torch.Tensor:
+        return (sigma**2 + self.pipe.sigma_data**2) / (sigma * self.pipe.sigma_data) ** 2
+
+    @torch.autocast('cuda', dtype=AUTOCAST_DTYPE)
+    def forward(self, inputs):
+        x_B_T_H_W_D, t_embedding_B_T_D, crossattn_emb, rope_emb_L_1_1_D, adaln_lora_B_T_3D, timesteps_B_T = inputs
+        x_B_T_H_W_O = self.final_layer(x_B_T_H_W_D, t_embedding_B_T_D, adaln_lora_B_T_3D=adaln_lora_B_T_3D)
+        net_output_B_C_T_H_W = self.unpatchify(x_B_T_H_W_O)
+        return net_output_B_C_T_H_W

--- a/models/anima.py
+++ b/models/anima.py
@@ -266,10 +266,9 @@ class AnimaPipeline(BasePipeline):
 
     def get_call_text_encoder_fn(self, text_encoder):
         """
-        Returns a function that computes:
+        Returns a function that computes both:
         - Qwen3 embeddings (for LLMAdapter cross-attention context)
         - T5 token IDs (for LLMAdapter embedding input)
-        - T5 attention mask 
         """
         def fn(captions, is_video):
             # Get Qwen3 embeddings
@@ -280,11 +279,12 @@ class AnimaPipeline(BasePipeline):
                 qwen_encoding.attention_mask
             )
 
-            # Get T5 token IDs and attention mask
+            # Get T5 token IDs
             t5_encoding = _tokenize_t5(self.t5_tokenizer, captions)
 
             return {
                 'qwen_embeds': qwen_embeds,
+                'qwen_attention_mask': qwen_encoding.attention_mask,
                 't5_input_ids': t5_encoding.input_ids,
                 't5_attention_mask': t5_encoding.attention_mask,
             }
@@ -295,22 +295,19 @@ class AnimaPipeline(BasePipeline):
         mask = inputs['mask']
 
         if self.cache_text_embeddings:
-            qwen_inputs = (
-                inputs['qwen_embeds'],
-                inputs['t5_input_ids'],
-                inputs['t5_attention_mask'], 
-            )
+            qwen_inputs = (inputs['qwen_embeds'],)
+            qwen_attention_mask = inputs.get('qwen_attention_mask')
+            t5_input_ids = inputs['t5_input_ids']
+            t5_attention_mask = inputs.get('t5_attention_mask')
         else:
             # Compute on-the-fly
             captions = inputs['caption']
             qwen_encoding = _tokenize_qwen(self.qwen_tokenizer, captions)
             qwen_inputs = (qwen_encoding.input_ids, qwen_encoding.attention_mask)
-            
+            qwen_attention_mask = qwen_encoding.attention_mask
             t5_encoding = _tokenize_t5(self.t5_tokenizer, captions)
             t5_input_ids = t5_encoding.input_ids
-            t5_attention_mask = t5_encoding.attention_mask 
-            
-            qwen_inputs = (*qwen_inputs, t5_input_ids, t5_attention_mask)
+            t5_attention_mask = t5_encoding.attention_mask
 
         bs, channels, num_frames, h, w = latents.shape
 
@@ -349,7 +346,7 @@ class AnimaPipeline(BasePipeline):
         noisy_latents = (1 - t_expanded)*latents + t_expanded*noise
         target = noise - latents
 
-        return (noisy_latents, t.view(-1, 1), *qwen_inputs), (target, mask)
+        return (noisy_latents, t.view(-1, 1), *qwen_inputs, qwen_attention_mask, t5_input_ids, t5_attention_mask), (target, mask)
 
     def to_layers(self):
         transformer = self.transformer
@@ -409,33 +406,17 @@ class InitialLayer(nn.Module):
     @torch.autocast('cuda', dtype=AUTOCAST_DTYPE)
     def forward(self, inputs):
         x_B_C_T_H_W, timesteps_B_T, *text_inputs = inputs
-        batch_size = x_B_C_T_H_W.shape[0]
-        target_device = x_B_C_T_H_W.device
-        target_dtype = x_B_C_T_H_W.dtype
 
+        # If qwen_model is not None, we need to compute embeddings on-the-fly.
+        # In cached mode, qwen_embeds is already computed and passed through.
         if self.qwen_model is None:
-            # Cached mode: (qwen_embeds, t5_input_ids, t5_attention_mask)
-            assert len(text_inputs) == 3, f"Expected cached inputs (qwen_embeds, t5_input_ids, t5_attention_mask), got {len(text_inputs)} items."
-            qwen_embeds, t5_input_ids, t5_attention_mask = text_inputs
-
-            # Move to target device
-            if qwen_embeds.device != target_device:
-                qwen_embeds = qwen_embeds.to(target_device)
-            if t5_input_ids.device != target_device:
-                t5_input_ids = t5_input_ids.to(target_device)
-            if t5_attention_mask.device != target_device:
-                t5_attention_mask = t5_attention_mask.to(target_device)
-                
-            if t5_input_ids.dtype != torch.long:
-                t5_input_ids = t5_input_ids.long()
-
-            # Process through LLM adapter
-            crossattn_emb = self.llm_adapter(qwen_embeds, t5_input_ids)
+            # Cached mode: (qwen_embeds, qwen_attention_mask, t5_input_ids, t5_attention_mask)
+            assert len(text_inputs) == 4, f"Expected cached inputs (qwen_embeds, qwen_attention_mask, t5_input_ids, t5_attention_mask), got {len(text_inputs)} items."
+            qwen_embeds, qwen_attention_mask, t5_input_ids, t5_attention_mask = text_inputs
         else:
             # Non-cached mode: (qwen_input_ids, qwen_attention_mask, t5_input_ids, t5_attention_mask)
             assert len(text_inputs) == 4, f"Expected non-cached inputs (qwen_input_ids, qwen_attention_mask, t5_input_ids, t5_attention_mask), got {len(text_inputs)} items."
             qwen_input_ids, qwen_attention_mask, t5_input_ids, t5_attention_mask = text_inputs
-            
             with torch.no_grad():
                 qwen_embeds = _compute_qwen_embeddings(
                     self.qwen_model,
@@ -443,33 +424,28 @@ class InitialLayer(nn.Module):
                     qwen_attention_mask,
                 )
 
-            # Move to target device
-            if qwen_embeds.device != target_device:
-                qwen_embeds = qwen_embeds.to(target_device)
-            if t5_input_ids.device != target_device:
-                t5_input_ids = t5_input_ids.to(target_device)
-            if t5_attention_mask.device != target_device:
-                t5_attention_mask = t5_attention_mask.to(target_device)
-                
-            if t5_input_ids.dtype != torch.long:
-                t5_input_ids = t5_input_ids.long()
+        target_device = x_B_C_T_H_W.device
+        if qwen_embeds.device != target_device:
+            qwen_embeds = qwen_embeds.to(target_device)
+        if qwen_attention_mask is not None and qwen_attention_mask.device != target_device:
+            qwen_attention_mask = qwen_attention_mask.to(target_device)
+        if t5_input_ids.device != target_device:
+            t5_input_ids = t5_input_ids.to(target_device)
+        if t5_attention_mask is not None and t5_attention_mask.device != target_device:
+            t5_attention_mask = t5_attention_mask.to(target_device)
+        if t5_input_ids.dtype != torch.long:
+            t5_input_ids = t5_input_ids.long()
 
-            # Process through LLM adapter to get final cross-attention embeddings
-            crossattn_emb = self.llm_adapter(qwen_embeds, t5_input_ids)
+        # Process through LLM adapter to get final cross-attention embeddings
+        # Pass attention masks for proper masking of padding tokens
+        crossattn_emb = self.llm_adapter(
+            qwen_embeds,
+            t5_input_ids,
+            target_attention_mask=t5_attention_mask,
+            source_attention_mask=qwen_attention_mask,
+        )
 
-
-        # This prevents attention leakage to garbage padding tokens
-        # and prevents model collapse with empty/short captions
-        if t5_attention_mask is not None:
-            # Create expanded mask: (B, seq_len, 1)
-            mask_expanded = t5_attention_mask.unsqueeze(-1).to(
-                device=crossattn_emb.device,
-                dtype=crossattn_emb.dtype
-            )
-            # Zero out padding positions: keep only valid tokens
-            crossattn_emb = crossattn_emb * mask_expanded
-
-        # Pad to 512 tokens if needed (padding is already zeros after masking)
+        # Pad to 512 tokens if needed
         if crossattn_emb.shape[1] < 512:
             crossattn_emb = F.pad(crossattn_emb, (0, 0, 0, 512 - crossattn_emb.shape[1]))
 
@@ -487,10 +463,8 @@ class InitialLayer(nn.Module):
         t_embedding_B_T_D, adaln_lora_B_T_3D = self.t_embedder(timesteps_B_T)
         t_embedding_B_T_D = self.t_embedding_norm(t_embedding_B_T_D)
 
-        # Note: timesteps_B_T is NOT included - it's only used here in InitialLayer
-        # Including it breaks pipeline parallelism (no gradient flows through unused tensors)
-        outputs = make_contiguous(x_B_T_H_W_D, t_embedding_B_T_D, crossattn_emb, rope_emb_L_1_1_D, adaln_lora_B_T_3D)
-        for item in outputs:  
+        outputs = make_contiguous(x_B_T_H_W_D, t_embedding_B_T_D, crossattn_emb, rope_emb_L_1_1_D, adaln_lora_B_T_3D, timesteps_B_T)
+        for item in outputs:
             item.requires_grad_(True)
         return outputs
 
@@ -504,13 +478,13 @@ class TransformerLayer(nn.Module):
 
     @torch.autocast('cuda', dtype=AUTOCAST_DTYPE)
     def forward(self, inputs):
-        x_B_T_H_W_D, t_embedding_B_T_D, crossattn_emb, rope_emb_L_1_1_D, adaln_lora_B_T_3D = inputs
+        x_B_T_H_W_D, t_embedding_B_T_D, crossattn_emb, rope_emb_L_1_1_D, adaln_lora_B_T_3D, timesteps_B_T = inputs
 
         self.offloader.wait_for_block(self.block_idx)
         x_B_T_H_W_D = self.block(x_B_T_H_W_D, t_embedding_B_T_D, crossattn_emb, rope_emb_L_1_1_D=rope_emb_L_1_1_D, adaln_lora_B_T_3D=adaln_lora_B_T_3D)
         self.offloader.submit_move_blocks_forward(self.block_idx)
 
-        return make_contiguous(x_B_T_H_W_D, t_embedding_B_T_D, crossattn_emb, rope_emb_L_1_1_D, adaln_lora_B_T_3D)
+        return make_contiguous(x_B_T_H_W_D, t_embedding_B_T_D, crossattn_emb, rope_emb_L_1_1_D, adaln_lora_B_T_3D, timesteps_B_T)
 
 
 class FinalLayer(nn.Module):
@@ -527,7 +501,7 @@ class FinalLayer(nn.Module):
 
     @torch.autocast('cuda', dtype=AUTOCAST_DTYPE)
     def forward(self, inputs):
-        x_B_T_H_W_D, t_embedding_B_T_D, crossattn_emb, rope_emb_L_1_1_D, adaln_lora_B_T_3D = inputs
+        x_B_T_H_W_D, t_embedding_B_T_D, crossattn_emb, rope_emb_L_1_1_D, adaln_lora_B_T_3D, timesteps_B_T = inputs
         x_B_T_H_W_O = self.final_layer(x_B_T_H_W_D, t_embedding_B_T_D, adaln_lora_B_T_3D=adaln_lora_B_T_3D)
         net_output_B_C_T_H_W = self.unpatchify(x_B_T_H_W_O)
         return net_output_B_C_T_H_W

--- a/models/anima.py
+++ b/models/anima.py
@@ -266,9 +266,10 @@ class AnimaPipeline(BasePipeline):
 
     def get_call_text_encoder_fn(self, text_encoder):
         """
-        Returns a function that computes both:
+        Returns a function that computes:
         - Qwen3 embeddings (for LLMAdapter cross-attention context)
         - T5 token IDs (for LLMAdapter embedding input)
+        - T5 attention mask 
         """
         def fn(captions, is_video):
             # Get Qwen3 embeddings
@@ -279,7 +280,7 @@ class AnimaPipeline(BasePipeline):
                 qwen_encoding.attention_mask
             )
 
-            # Get T5 token IDs
+            # Get T5 token IDs and attention mask
             t5_encoding = _tokenize_t5(self.t5_tokenizer, captions)
 
             return {
@@ -294,15 +295,22 @@ class AnimaPipeline(BasePipeline):
         mask = inputs['mask']
 
         if self.cache_text_embeddings:
-            qwen_inputs = (inputs['qwen_embeds'],)
-            t5_input_ids = inputs['t5_input_ids']
+            qwen_inputs = (
+                inputs['qwen_embeds'],
+                inputs['t5_input_ids'],
+                inputs['t5_attention_mask'], 
+            )
         else:
             # Compute on-the-fly
             captions = inputs['caption']
             qwen_encoding = _tokenize_qwen(self.qwen_tokenizer, captions)
             qwen_inputs = (qwen_encoding.input_ids, qwen_encoding.attention_mask)
+            
             t5_encoding = _tokenize_t5(self.t5_tokenizer, captions)
             t5_input_ids = t5_encoding.input_ids
+            t5_attention_mask = t5_encoding.attention_mask 
+            
+            qwen_inputs = (*qwen_inputs, t5_input_ids, t5_attention_mask)
 
         bs, channels, num_frames, h, w = latents.shape
 
@@ -341,7 +349,7 @@ class AnimaPipeline(BasePipeline):
         noisy_latents = (1 - t_expanded)*latents + t_expanded*noise
         target = noise - latents
 
-        return (noisy_latents, t.view(-1, 1), *qwen_inputs, t5_input_ids), (target, mask)
+        return (noisy_latents, t.view(-1, 1), *qwen_inputs), (target, mask)
 
     def to_layers(self):
         transformer = self.transformer
@@ -401,15 +409,33 @@ class InitialLayer(nn.Module):
     @torch.autocast('cuda', dtype=AUTOCAST_DTYPE)
     def forward(self, inputs):
         x_B_C_T_H_W, timesteps_B_T, *text_inputs = inputs
+        batch_size = x_B_C_T_H_W.shape[0]
+        target_device = x_B_C_T_H_W.device
+        target_dtype = x_B_C_T_H_W.dtype
 
-        # If qwen_model is not None, we need to compute embeddings on-the-fly.
-        # In cached mode, qwen_embeds is already computed and passed through.
         if self.qwen_model is None:
-            assert len(text_inputs) == 2, f"Expected cached inputs (qwen_embeds, t5_input_ids), got {len(text_inputs)} items."
-            qwen_embeds, t5_input_ids = text_inputs
+            # Cached mode: (qwen_embeds, t5_input_ids, t5_attention_mask)
+            assert len(text_inputs) == 3, f"Expected cached inputs (qwen_embeds, t5_input_ids, t5_attention_mask), got {len(text_inputs)} items."
+            qwen_embeds, t5_input_ids, t5_attention_mask = text_inputs
+
+            # Move to target device
+            if qwen_embeds.device != target_device:
+                qwen_embeds = qwen_embeds.to(target_device)
+            if t5_input_ids.device != target_device:
+                t5_input_ids = t5_input_ids.to(target_device)
+            if t5_attention_mask.device != target_device:
+                t5_attention_mask = t5_attention_mask.to(target_device)
+                
+            if t5_input_ids.dtype != torch.long:
+                t5_input_ids = t5_input_ids.long()
+
+            # Process through LLM adapter
+            crossattn_emb = self.llm_adapter(qwen_embeds, t5_input_ids)
         else:
-            assert len(text_inputs) == 3, f"Expected non-cached inputs (qwen_input_ids, qwen_attention_mask, t5_input_ids), got {len(text_inputs)} items."
-            qwen_input_ids, qwen_attention_mask, t5_input_ids = text_inputs
+            # Non-cached mode: (qwen_input_ids, qwen_attention_mask, t5_input_ids, t5_attention_mask)
+            assert len(text_inputs) == 4, f"Expected non-cached inputs (qwen_input_ids, qwen_attention_mask, t5_input_ids, t5_attention_mask), got {len(text_inputs)} items."
+            qwen_input_ids, qwen_attention_mask, t5_input_ids, t5_attention_mask = text_inputs
+            
             with torch.no_grad():
                 qwen_embeds = _compute_qwen_embeddings(
                     self.qwen_model,
@@ -417,18 +443,33 @@ class InitialLayer(nn.Module):
                     qwen_attention_mask,
                 )
 
-        target_device = x_B_C_T_H_W.device
-        if qwen_embeds.device != target_device:
-            qwen_embeds = qwen_embeds.to(target_device)
-        if t5_input_ids.device != target_device:
-            t5_input_ids = t5_input_ids.to(target_device)
-        if t5_input_ids.dtype != torch.long:
-            t5_input_ids = t5_input_ids.long()
+            # Move to target device
+            if qwen_embeds.device != target_device:
+                qwen_embeds = qwen_embeds.to(target_device)
+            if t5_input_ids.device != target_device:
+                t5_input_ids = t5_input_ids.to(target_device)
+            if t5_attention_mask.device != target_device:
+                t5_attention_mask = t5_attention_mask.to(target_device)
+                
+            if t5_input_ids.dtype != torch.long:
+                t5_input_ids = t5_input_ids.long()
 
-        # Process through LLM adapter to get final cross-attention embeddings
-        crossattn_emb = self.llm_adapter(qwen_embeds, t5_input_ids)
+            # Process through LLM adapter to get final cross-attention embeddings
+            crossattn_emb = self.llm_adapter(qwen_embeds, t5_input_ids)
 
-        # Pad to 512 tokens if needed
+
+        # This prevents attention leakage to garbage padding tokens
+        # and prevents model collapse with empty/short captions
+        if t5_attention_mask is not None:
+            # Create expanded mask: (B, seq_len, 1)
+            mask_expanded = t5_attention_mask.unsqueeze(-1).to(
+                device=crossattn_emb.device,
+                dtype=crossattn_emb.dtype
+            )
+            # Zero out padding positions: keep only valid tokens
+            crossattn_emb = crossattn_emb * mask_expanded
+
+        # Pad to 512 tokens if needed (padding is already zeros after masking)
         if crossattn_emb.shape[1] < 512:
             crossattn_emb = F.pad(crossattn_emb, (0, 0, 0, 512 - crossattn_emb.shape[1]))
 
@@ -446,8 +487,10 @@ class InitialLayer(nn.Module):
         t_embedding_B_T_D, adaln_lora_B_T_3D = self.t_embedder(timesteps_B_T)
         t_embedding_B_T_D = self.t_embedding_norm(t_embedding_B_T_D)
 
-        outputs = make_contiguous(x_B_T_H_W_D, t_embedding_B_T_D, crossattn_emb, rope_emb_L_1_1_D, adaln_lora_B_T_3D, timesteps_B_T)
-        for item in outputs:
+        # Note: timesteps_B_T is NOT included - it's only used here in InitialLayer
+        # Including it breaks pipeline parallelism (no gradient flows through unused tensors)
+        outputs = make_contiguous(x_B_T_H_W_D, t_embedding_B_T_D, crossattn_emb, rope_emb_L_1_1_D, adaln_lora_B_T_3D)
+        for item in outputs:  
             item.requires_grad_(True)
         return outputs
 
@@ -461,13 +504,13 @@ class TransformerLayer(nn.Module):
 
     @torch.autocast('cuda', dtype=AUTOCAST_DTYPE)
     def forward(self, inputs):
-        x_B_T_H_W_D, t_embedding_B_T_D, crossattn_emb, rope_emb_L_1_1_D, adaln_lora_B_T_3D, timesteps_B_T = inputs
+        x_B_T_H_W_D, t_embedding_B_T_D, crossattn_emb, rope_emb_L_1_1_D, adaln_lora_B_T_3D = inputs
 
         self.offloader.wait_for_block(self.block_idx)
         x_B_T_H_W_D = self.block(x_B_T_H_W_D, t_embedding_B_T_D, crossattn_emb, rope_emb_L_1_1_D=rope_emb_L_1_1_D, adaln_lora_B_T_3D=adaln_lora_B_T_3D)
         self.offloader.submit_move_blocks_forward(self.block_idx)
 
-        return make_contiguous(x_B_T_H_W_D, t_embedding_B_T_D, crossattn_emb, rope_emb_L_1_1_D, adaln_lora_B_T_3D, timesteps_B_T)
+        return make_contiguous(x_B_T_H_W_D, t_embedding_B_T_D, crossattn_emb, rope_emb_L_1_1_D, adaln_lora_B_T_3D)
 
 
 class FinalLayer(nn.Module):
@@ -484,7 +527,7 @@ class FinalLayer(nn.Module):
 
     @torch.autocast('cuda', dtype=AUTOCAST_DTYPE)
     def forward(self, inputs):
-        x_B_T_H_W_D, t_embedding_B_T_D, crossattn_emb, rope_emb_L_1_1_D, adaln_lora_B_T_3D, timesteps_B_T = inputs
+        x_B_T_H_W_D, t_embedding_B_T_D, crossattn_emb, rope_emb_L_1_1_D, adaln_lora_B_T_3D = inputs
         x_B_T_H_W_O = self.final_layer(x_B_T_H_W_D, t_embedding_B_T_D, adaln_lora_B_T_3D=adaln_lora_B_T_3D)
         net_output_B_C_T_H_W = self.unpatchify(x_B_T_H_W_O)
         return net_output_B_C_T_H_W

--- a/models/anima.py
+++ b/models/anima.py
@@ -3,7 +3,6 @@
 # Uses Qwen Image VAE (same architecture/normalization as Wan VAE)
 
 import math
-import random
 
 import torch
 from torch import nn
@@ -22,38 +21,6 @@ from utils.offloading import ModelOffloader
 
 
 KEEP_IN_HIGH_PRECISION = ['x_embedder', 't_embedder', 't_embedding_norm', 'final_layer', 'llm_adapter']
-
-
-def _shuffle_tags(caption, delimiter=', ', keep_first_n=0):
-    """
-    Shuffle tags in a caption string at training time.
-
-    Args:
-        caption: Caption string with tags separated by delimiter
-        delimiter: Tag separator (default ", " for danbooru-style tags)
-        keep_first_n: Keep the first N tags in place, shuffle the rest
-                     (useful for keeping trigger words at the start)
-
-    Returns:
-        Caption with tags shuffled
-    """
-    if not caption or delimiter not in caption:
-        return caption
-
-    tags = caption.split(delimiter)
-    if len(tags) <= 1:
-        return caption
-
-    # Keep first N tags in place, shuffle the rest
-    if keep_first_n > 0 and keep_first_n < len(tags):
-        prefix = tags[:keep_first_n]
-        suffix = tags[keep_first_n:]
-        random.shuffle(suffix)
-        tags = prefix + suffix
-    else:
-        random.shuffle(tags)
-
-    return delimiter.join(tags)
 
 
 def _tokenize_t5(tokenizer, prompts):
@@ -130,14 +97,6 @@ class AnimaPipeline(BasePipeline):
 
         # Load transformer directly to CUDA (faster init, single GPU only)
         self.load_to_cuda = self.model_config.get('load_to_cuda', False)
-
-        # Training-time tag shuffling (only works when cache_text_embeddings=false)
-        self.shuffle_tags = self.model_config.get('shuffle_tags', False)
-        self.tag_delimiter = self.model_config.get('tag_delimiter', ', ')
-        self.keep_first_n_tags = self.model_config.get('keep_first_n_tags', 0)
-        if self.shuffle_tags and self.cache_text_embeddings:
-            print("WARNING: shuffle_tags requires cache_text_embeddings=false to work at training time. "
-                  "With cache_text_embeddings=true, use cache_shuffle_num in your dataset config instead.")
 
         # VAE - Qwen Image VAE (16 channel, same architecture/normalization as Wan VAE)
         self.vae = WanVAE(
@@ -340,14 +299,6 @@ class AnimaPipeline(BasePipeline):
         else:
             # Compute on-the-fly
             captions = inputs['caption']
-
-            # Apply training-time tag shuffling if enabled
-            if self.shuffle_tags:
-                if isinstance(captions, list):
-                    captions = [_shuffle_tags(c, self.tag_delimiter, self.keep_first_n_tags) for c in captions]
-                else:
-                    captions = _shuffle_tags(captions, self.tag_delimiter, self.keep_first_n_tags)
-
             qwen_encoding = _tokenize_qwen(self.qwen_tokenizer, captions)
             qwen_inputs = (qwen_encoding.input_ids, qwen_encoding.attention_mask)
             t5_encoding = _tokenize_t5(self.t5_tokenizer, captions)

--- a/models/anima.py
+++ b/models/anima.py
@@ -284,7 +284,6 @@ class AnimaPipeline(BasePipeline):
 
             return {
                 'qwen_embeds': qwen_embeds,
-                'qwen_attention_mask': qwen_encoding.attention_mask,
                 't5_input_ids': t5_encoding.input_ids,
                 't5_attention_mask': t5_encoding.attention_mask,
             }
@@ -296,18 +295,14 @@ class AnimaPipeline(BasePipeline):
 
         if self.cache_text_embeddings:
             qwen_inputs = (inputs['qwen_embeds'],)
-            qwen_attention_mask = inputs.get('qwen_attention_mask')
             t5_input_ids = inputs['t5_input_ids']
-            t5_attention_mask = inputs.get('t5_attention_mask')
         else:
             # Compute on-the-fly
             captions = inputs['caption']
             qwen_encoding = _tokenize_qwen(self.qwen_tokenizer, captions)
             qwen_inputs = (qwen_encoding.input_ids, qwen_encoding.attention_mask)
-            qwen_attention_mask = qwen_encoding.attention_mask
             t5_encoding = _tokenize_t5(self.t5_tokenizer, captions)
             t5_input_ids = t5_encoding.input_ids
-            t5_attention_mask = t5_encoding.attention_mask
 
         bs, channels, num_frames, h, w = latents.shape
 
@@ -346,7 +341,7 @@ class AnimaPipeline(BasePipeline):
         noisy_latents = (1 - t_expanded)*latents + t_expanded*noise
         target = noise - latents
 
-        return (noisy_latents, t.view(-1, 1), *qwen_inputs, qwen_attention_mask, t5_input_ids, t5_attention_mask), (target, mask)
+        return (noisy_latents, t.view(-1, 1), *qwen_inputs, t5_input_ids), (target, mask)
 
     def to_layers(self):
         transformer = self.transformer
@@ -410,13 +405,11 @@ class InitialLayer(nn.Module):
         # If qwen_model is not None, we need to compute embeddings on-the-fly.
         # In cached mode, qwen_embeds is already computed and passed through.
         if self.qwen_model is None:
-            # Cached mode: (qwen_embeds, qwen_attention_mask, t5_input_ids, t5_attention_mask)
-            assert len(text_inputs) == 4, f"Expected cached inputs (qwen_embeds, qwen_attention_mask, t5_input_ids, t5_attention_mask), got {len(text_inputs)} items."
-            qwen_embeds, qwen_attention_mask, t5_input_ids, t5_attention_mask = text_inputs
+            assert len(text_inputs) == 2, f"Expected cached inputs (qwen_embeds, t5_input_ids), got {len(text_inputs)} items."
+            qwen_embeds, t5_input_ids = text_inputs
         else:
-            # Non-cached mode: (qwen_input_ids, qwen_attention_mask, t5_input_ids, t5_attention_mask)
-            assert len(text_inputs) == 4, f"Expected non-cached inputs (qwen_input_ids, qwen_attention_mask, t5_input_ids, t5_attention_mask), got {len(text_inputs)} items."
-            qwen_input_ids, qwen_attention_mask, t5_input_ids, t5_attention_mask = text_inputs
+            assert len(text_inputs) == 3, f"Expected non-cached inputs (qwen_input_ids, qwen_attention_mask, t5_input_ids), got {len(text_inputs)} items."
+            qwen_input_ids, qwen_attention_mask, t5_input_ids = text_inputs
             with torch.no_grad():
                 qwen_embeds = _compute_qwen_embeddings(
                     self.qwen_model,
@@ -427,23 +420,13 @@ class InitialLayer(nn.Module):
         target_device = x_B_C_T_H_W.device
         if qwen_embeds.device != target_device:
             qwen_embeds = qwen_embeds.to(target_device)
-        if qwen_attention_mask is not None and qwen_attention_mask.device != target_device:
-            qwen_attention_mask = qwen_attention_mask.to(target_device)
         if t5_input_ids.device != target_device:
             t5_input_ids = t5_input_ids.to(target_device)
-        if t5_attention_mask is not None and t5_attention_mask.device != target_device:
-            t5_attention_mask = t5_attention_mask.to(target_device)
         if t5_input_ids.dtype != torch.long:
             t5_input_ids = t5_input_ids.long()
 
         # Process through LLM adapter to get final cross-attention embeddings
-        # Pass attention masks for proper masking of padding tokens
-        crossattn_emb = self.llm_adapter(
-            qwen_embeds,
-            t5_input_ids,
-            target_attention_mask=t5_attention_mask,
-            source_attention_mask=qwen_attention_mask,
-        )
+        crossattn_emb = self.llm_adapter(qwen_embeds, t5_input_ids)
 
         # Pad to 512 tokens if needed
         if crossattn_emb.shape[1] < 512:

--- a/models/anima_modeling.py
+++ b/models/anima_modeling.py
@@ -1,0 +1,230 @@
+# Anima model - MiniTrainDIT with LLMAdapter for bridging Qwen3 embeddings
+# Based on ComfyUI's comfy/ldm/anima/model.py
+
+import torch
+from torch import nn
+import torch.nn.functional as F
+
+from models.cosmos_predict2_modeling import MiniTrainDIT
+
+
+def rotate_half(x):
+    x1 = x[..., : x.shape[-1] // 2]
+    x2 = x[..., x.shape[-1] // 2 :]
+    return torch.cat((-x2, x1), dim=-1)
+
+
+def apply_rotary_pos_emb(x, cos, sin, unsqueeze_dim=1):
+    cos = cos.unsqueeze(unsqueeze_dim)
+    sin = sin.unsqueeze(unsqueeze_dim)
+    x_embed = (x * cos) + (rotate_half(x) * sin)
+    return x_embed
+
+
+class RotaryEmbedding(nn.Module):
+    def __init__(self, head_dim):
+        super().__init__()
+        self.rope_theta = 10000
+        inv_freq = 1.0 / (self.rope_theta ** (torch.arange(0, head_dim, 2, dtype=torch.int64).to(dtype=torch.float) / head_dim))
+        self.register_buffer("inv_freq", inv_freq, persistent=False)
+
+    @torch.no_grad()
+    def forward(self, x, position_ids):
+        inv_freq_expanded = self.inv_freq[None, :, None].float().expand(position_ids.shape[0], -1, 1).to(x.device)
+        position_ids_expanded = position_ids[:, None, :].float()
+
+        device_type = x.device.type if isinstance(x.device.type, str) and x.device.type != "mps" else "cpu"
+        with torch.autocast(device_type=device_type, enabled=False):  # Force float32
+            freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1, 2)
+            emb = torch.cat((freqs, freqs), dim=-1)
+            cos = emb.cos()
+            sin = emb.sin()
+
+        return cos.to(dtype=x.dtype), sin.to(dtype=x.dtype)
+
+
+class LLMAdapterAttention(nn.Module):
+    def __init__(self, query_dim, context_dim, n_heads, head_dim):
+        super().__init__()
+
+        inner_dim = head_dim * n_heads
+        self.n_heads = n_heads
+        self.head_dim = head_dim
+        self.query_dim = query_dim
+        self.context_dim = context_dim
+
+        self.q_proj = nn.Linear(query_dim, inner_dim, bias=False)
+        self.q_norm = nn.RMSNorm(self.head_dim, eps=1e-6)
+
+        self.k_proj = nn.Linear(context_dim, inner_dim, bias=False)
+        self.k_norm = nn.RMSNorm(self.head_dim, eps=1e-6)
+
+        self.v_proj = nn.Linear(context_dim, inner_dim, bias=False)
+
+        self.o_proj = nn.Linear(inner_dim, query_dim, bias=False)
+
+    def forward(self, x, mask=None, context=None, position_embeddings=None, position_embeddings_context=None):
+        context = x if context is None else context
+        input_shape = x.shape[:-1]
+        q_shape = (*input_shape, self.n_heads, self.head_dim)
+        context_shape = context.shape[:-1]
+        kv_shape = (*context_shape, self.n_heads, self.head_dim)
+
+        query_states = self.q_norm(self.q_proj(x).view(q_shape)).transpose(1, 2)
+        key_states = self.k_norm(self.k_proj(context).view(kv_shape)).transpose(1, 2)
+        value_states = self.v_proj(context).view(kv_shape).transpose(1, 2)
+
+        if position_embeddings is not None:
+            assert position_embeddings_context is not None
+            cos, sin = position_embeddings
+            query_states = apply_rotary_pos_emb(query_states, cos, sin)
+            cos, sin = position_embeddings_context
+            key_states = apply_rotary_pos_emb(key_states, cos, sin)
+
+        attn_output = F.scaled_dot_product_attention(query_states, key_states, value_states, attn_mask=mask)
+
+        attn_output = attn_output.transpose(1, 2).reshape(*input_shape, -1).contiguous()
+        attn_output = self.o_proj(attn_output)
+        return attn_output
+
+    def init_weights(self):
+        torch.nn.init.zeros_(self.o_proj.weight)
+
+
+class LLMAdapterTransformerBlock(nn.Module):
+    def __init__(self, source_dim, model_dim, num_heads=16, mlp_ratio=4.0, use_self_attn=False, layer_norm=False):
+        super().__init__()
+        self.use_self_attn = use_self_attn
+
+        if self.use_self_attn:
+            self.norm_self_attn = nn.LayerNorm(model_dim) if layer_norm else nn.RMSNorm(model_dim, eps=1e-6)
+            self.self_attn = LLMAdapterAttention(
+                query_dim=model_dim,
+                context_dim=model_dim,
+                n_heads=num_heads,
+                head_dim=model_dim//num_heads,
+            )
+
+        self.norm_cross_attn = nn.LayerNorm(model_dim) if layer_norm else nn.RMSNorm(model_dim, eps=1e-6)
+        self.cross_attn = LLMAdapterAttention(
+            query_dim=model_dim,
+            context_dim=source_dim,
+            n_heads=num_heads,
+            head_dim=model_dim//num_heads,
+        )
+
+        self.norm_mlp = nn.LayerNorm(model_dim) if layer_norm else nn.RMSNorm(model_dim, eps=1e-6)
+        self.mlp = nn.Sequential(
+            nn.Linear(model_dim, int(model_dim * mlp_ratio)),
+            nn.GELU(),
+            nn.Linear(int(model_dim * mlp_ratio), model_dim)
+        )
+
+    def forward(self, x, context, target_attention_mask=None, source_attention_mask=None, position_embeddings=None, position_embeddings_context=None):
+        if self.use_self_attn:
+            normed = self.norm_self_attn(x)
+            attn_out = self.self_attn(normed, mask=target_attention_mask, position_embeddings=position_embeddings, position_embeddings_context=position_embeddings)
+            x = x + attn_out
+
+        normed = self.norm_cross_attn(x)
+        attn_out = self.cross_attn(normed, mask=source_attention_mask, context=context, position_embeddings=position_embeddings, position_embeddings_context=position_embeddings_context)
+        x = x + attn_out
+
+        x = x + self.mlp(self.norm_mlp(x))
+        return x
+
+    def init_weights(self):
+        torch.nn.init.zeros_(self.mlp[2].weight)
+        self.cross_attn.init_weights()
+
+
+class LLMAdapter(nn.Module):
+    """
+    LLMAdapter bridges Qwen3 embeddings to the diffusion model via a transformer-based module.
+
+    Takes:
+    - source_hidden_states: Qwen3 embeddings (B, seq_len, 1024)
+    - target_input_ids: T5 token IDs (B, seq_len)
+
+    Returns:
+    - Processed embeddings for cross-attention in the diffusion model
+    """
+    def __init__(
+            self,
+            source_dim=1024,
+            target_dim=1024,
+            model_dim=1024,
+            num_layers=6,
+            num_heads=16,
+            use_self_attn=True,
+            layer_norm=False,
+        ):
+        super().__init__()
+
+        self.embed = nn.Embedding(32128, target_dim)  # T5 vocab size
+        if model_dim != target_dim:
+            self.in_proj = nn.Linear(target_dim, model_dim)
+        else:
+            self.in_proj = nn.Identity()
+        self.rotary_emb = RotaryEmbedding(model_dim//num_heads)
+        self.blocks = nn.ModuleList([
+            LLMAdapterTransformerBlock(source_dim, model_dim, num_heads=num_heads, use_self_attn=use_self_attn, layer_norm=layer_norm) for _ in range(num_layers)
+        ])
+        self.out_proj = nn.Linear(model_dim, target_dim)
+        self.norm = nn.RMSNorm(target_dim, eps=1e-6)
+
+    def forward(self, source_hidden_states, target_input_ids, target_attention_mask=None, source_attention_mask=None):
+        if target_attention_mask is not None:
+            target_attention_mask = target_attention_mask.to(torch.bool)
+            if target_attention_mask.ndim == 2:
+                target_attention_mask = target_attention_mask.unsqueeze(1).unsqueeze(1)
+
+        if source_attention_mask is not None:
+            source_attention_mask = source_attention_mask.to(torch.bool)
+            if source_attention_mask.ndim == 2:
+                source_attention_mask = source_attention_mask.unsqueeze(1).unsqueeze(1)
+
+        x = self.in_proj(self.embed(target_input_ids))
+        context = source_hidden_states
+        position_ids = torch.arange(x.shape[1], device=x.device).unsqueeze(0)
+        position_ids_context = torch.arange(context.shape[1], device=x.device).unsqueeze(0)
+        position_embeddings = self.rotary_emb(x, position_ids)
+        position_embeddings_context = self.rotary_emb(x, position_ids_context)
+        for block in self.blocks:
+            x = block(x, context, target_attention_mask=target_attention_mask, source_attention_mask=source_attention_mask, position_embeddings=position_embeddings, position_embeddings_context=position_embeddings_context)
+        return self.norm(self.out_proj(x))
+
+
+class Anima(MiniTrainDIT):
+    """
+    Anima model - extends MiniTrainDIT (Cosmos-Predict2 base) with an LLMAdapter
+    for processing dual text encoder outputs (Qwen3 + T5).
+    """
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # LLMAdapter with default Anima configuration
+        self.llm_adapter = LLMAdapter(
+            source_dim=1024,   # Qwen3 embedding dimension
+            target_dim=1024,   # Output dimension (matches crossattn_emb_channels)
+            model_dim=1024,
+            num_layers=6,
+            num_heads=16,
+            use_self_attn=True,
+            layer_norm=False,
+        )
+
+    def preprocess_text_embeds(self, text_embeds, text_ids):
+        """
+        Process text embeddings through the LLM adapter.
+
+        Args:
+            text_embeds: Qwen3 embeddings (B, seq_len, 1024)
+            text_ids: T5 token IDs (B, seq_len)
+
+        Returns:
+            Processed embeddings for cross-attention
+        """
+        if text_ids is not None:
+            return self.llm_adapter(text_embeds, text_ids)
+        else:
+            return text_embeds

--- a/models/anima_modeling.py
+++ b/models/anima_modeling.py
@@ -213,33 +213,18 @@ class Anima(MiniTrainDIT):
             layer_norm=False,
         )
 
-    def preprocess_text_embeds(
-        self,
-        text_embeds,
-        text_ids,
-        t5_attention_mask=None,
-        qwen_attention_mask=None,
-    ):
+    def preprocess_text_embeds(self, text_embeds, text_ids):
         """
         Process text embeddings through the LLM adapter.
 
         Args:
-            text_embeds: Qwen3 embeddings (B, seq_len, 1024) - source for cross-attention
-            text_ids: T5 token IDs (B, seq_len) - target for embedding lookup
-            t5_attention_mask: Optional attention mask for T5 tokens (B, seq_len)
-                               True/1 = attend, False/0 = ignore (padding)
-            qwen_attention_mask: Optional attention mask for Qwen embeddings (B, seq_len)
-                                 True/1 = attend, False/0 = ignore (padding)
+            text_embeds: Qwen3 embeddings (B, seq_len, 1024)
+            text_ids: T5 token IDs (B, seq_len)
 
         Returns:
             Processed embeddings for cross-attention
         """
         if text_ids is not None:
-            return self.llm_adapter(
-                text_embeds,
-                text_ids,
-                target_attention_mask=t5_attention_mask,
-                source_attention_mask=qwen_attention_mask,
-            )
+            return self.llm_adapter(text_embeds, text_ids)
         else:
             return text_embeds

--- a/models/anima_modeling.py
+++ b/models/anima_modeling.py
@@ -213,18 +213,33 @@ class Anima(MiniTrainDIT):
             layer_norm=False,
         )
 
-    def preprocess_text_embeds(self, text_embeds, text_ids):
+    def preprocess_text_embeds(
+        self,
+        text_embeds,
+        text_ids,
+        t5_attention_mask=None,
+        qwen_attention_mask=None,
+    ):
         """
         Process text embeddings through the LLM adapter.
 
         Args:
-            text_embeds: Qwen3 embeddings (B, seq_len, 1024)
-            text_ids: T5 token IDs (B, seq_len)
+            text_embeds: Qwen3 embeddings (B, seq_len, 1024) - source for cross-attention
+            text_ids: T5 token IDs (B, seq_len) - target for embedding lookup
+            t5_attention_mask: Optional attention mask for T5 tokens (B, seq_len)
+                               True/1 = attend, False/0 = ignore (padding)
+            qwen_attention_mask: Optional attention mask for Qwen embeddings (B, seq_len)
+                                 True/1 = attend, False/0 = ignore (padding)
 
         Returns:
             Processed embeddings for cross-attention
         """
         if text_ids is not None:
-            return self.llm_adapter(text_embeds, text_ids)
+            return self.llm_adapter(
+                text_embeds,
+                text_ids,
+                target_attention_mask=t5_attention_mask,
+                source_attention_mask=qwen_attention_mask,
+            )
         else:
             return text_embeds

--- a/train.py
+++ b/train.py
@@ -339,6 +339,9 @@ if __name__ == '__main__':
     elif model_type == 'cosmos_predict2':
         from models import cosmos_predict2
         model = cosmos_predict2.CosmosPredict2Pipeline(config)
+    elif model_type == 'anima':
+        from models import anima
+        model = anima.AnimaPipeline(config)
     elif model_type == 'omnigen2':
         from models import omnigen2
         model = omnigen2.OmniGen2Pipeline(config)
@@ -543,10 +546,10 @@ if __name__ == '__main__':
             dir=logging_dir
         )
 
-    # Block swapping
+    # Block swapping (supports both LoRA and full-finetune)
     if blocks_to_swap := config.get('blocks_to_swap', 0):
         assert config['pipeline_stages'] == 1, 'Block swapping only works with pipeline_stages=1'
-        assert 'adapter' in config, 'Block swapping only works when training LoRA'
+        # Block swapping now supports both LoRA and full-finetune
         # Don't automatically move to GPU, we'll do that ourselves.
         def to(self, *args, **kwargs):
             pass

--- a/utils/cache.py
+++ b/utils/cache.py
@@ -37,7 +37,9 @@ class Cache:
     def init(self):
         print('[CACHE] Initializing')
         # create database
-        self.con = sqlite3.connect(self.metadata_db, autocommit=False)
+        # Note: autocommit=False is Python 3.12+, use isolation_level for 3.11 compatibility
+        # Default isolation_level="" means transactions are used (equivalent to autocommit=False)
+        self.con = sqlite3.connect(self.metadata_db)
 
         # check fingerprint, clear cache if different
         self.con.execute('CREATE TABLE IF NOT EXISTS fingerprint(value)')

--- a/utils/dataset.py
+++ b/utils/dataset.py
@@ -711,7 +711,7 @@ class DirectoryDataset:
                 captions = example['caption'][0]
             if captions is None and caption_file:
                 with open(caption_file) as f:
-                    content = [f.read().strip()]
+                    captions = [f.read().strip()]
             if captions is None:
                 captions = ['']
                 logger.warning(f'Cound not find caption for {image_file}. Using empty caption.')

--- a/utils/dataset.py
+++ b/utils/dataset.py
@@ -711,16 +711,7 @@ class DirectoryDataset:
                 captions = example['caption'][0]
             if captions is None and caption_file:
                 with open(caption_file) as f:
-                    content = f.read().strip()
-                    # Support multi-line caption files: each line is a separate caption
-                    # This allows random caption selection during training
-                    lines = [line.strip() for line in content.split('\n') if line.strip()]
-                    if len(lines) > 1:
-                        # Multi-line file: treat each line as a separate caption
-                        captions = lines
-                    else:
-                        # Single line or single caption
-                        captions = [content]
+                    content = [f.read().strip()]
             if captions is None:
                 captions = ['']
                 logger.warning(f'Cound not find caption for {image_file}. Using empty caption.')

--- a/utils/dataset.py
+++ b/utils/dataset.py
@@ -44,52 +44,16 @@ def shuffle_with_seed(l, seed=None):
     random.setstate(rng_state)
 
 
-TAG_SHUFFLE_PREFIX = 'special:'  # Case-insensitive prefix to mark captions for tag shuffling
-
-
 def shuffle_captions(captions: list[str], count: int = 0, delimiter: str = ', ', caption_prefix: str = '') -> list[str]:
-    """
-    Shuffle captions with special handling for tag-style vs natural language captions.
-
-    Captions starting with "Special:" (case-insensitive) are treated as tag-style:
-    - The "Special:" prefix is removed
-    - Tags are shuffled based on the delimiter
-
-    Captions without the prefix are kept as-is (natural language, no shuffling).
-
-    Args:
-        captions: List of caption strings
-        count: Number of shuffled variations to create (0 = no shuffle variations)
-        delimiter: Tag delimiter for shuffling (default ", ")
-        caption_prefix: Prefix to add to all captions after processing
-
-    Example:
-        "Special: 1girl, blue hair, smile" → shuffled: "blue hair, 1girl, smile"
-        "A beautiful anime girl" → kept as-is: "A beautiful anime girl"
-    """
-    def process_caption(caption: str, should_shuffle: bool) -> str:
-        # Check for special tag-shuffle prefix (case-insensitive)
-        if caption.lower().startswith(TAG_SHUFFLE_PREFIX):
-            # Remove the prefix and strip whitespace
-            caption = caption[len(TAG_SHUFFLE_PREFIX):].strip()
-            if should_shuffle:
-                # Shuffle tags
-                split = caption.split(delimiter)
-                random.shuffle(split)
-                caption = delimiter.join(split)
-        # Captions without prefix are kept as-is (no shuffling)
-        return caption_prefix + caption
-
     if count == 0:
-        # No shuffle variations requested - still process prefix but don't shuffle
-        return [process_caption(c, should_shuffle=False) for c in captions]
+        return [caption_prefix + c for c in captions]
 
-    # Create multiple shuffled variations
-    result = []
-    for caption in captions:
-        for _ in range(count):
-            result.append(process_caption(caption, should_shuffle=True))
-    return result
+    def shuffle_caption(caption: str, delimiter: str = ", ") -> str:
+        split = caption.split(delimiter)
+        random.shuffle(split)
+        return delimiter.join(split)
+
+    return [caption_prefix + shuffle_caption(caption, delimiter) for caption in captions for _ in range(count)]
 
 
 def bucket_suffix(key):

--- a/utils/dataset.py
+++ b/utils/dataset.py
@@ -44,16 +44,52 @@ def shuffle_with_seed(l, seed=None):
     random.setstate(rng_state)
 
 
+TAG_SHUFFLE_PREFIX = 'special:'  # Case-insensitive prefix to mark captions for tag shuffling
+
+
 def shuffle_captions(captions: list[str], count: int = 0, delimiter: str = ', ', caption_prefix: str = '') -> list[str]:
+    """
+    Shuffle captions with special handling for tag-style vs natural language captions.
+
+    Captions starting with "Special:" (case-insensitive) are treated as tag-style:
+    - The "Special:" prefix is removed
+    - Tags are shuffled based on the delimiter
+
+    Captions without the prefix are kept as-is (natural language, no shuffling).
+
+    Args:
+        captions: List of caption strings
+        count: Number of shuffled variations to create (0 = no shuffle variations)
+        delimiter: Tag delimiter for shuffling (default ", ")
+        caption_prefix: Prefix to add to all captions after processing
+
+    Example:
+        "Special: 1girl, blue hair, smile" → shuffled: "blue hair, 1girl, smile"
+        "A beautiful anime girl" → kept as-is: "A beautiful anime girl"
+    """
+    def process_caption(caption: str, should_shuffle: bool) -> str:
+        # Check for special tag-shuffle prefix (case-insensitive)
+        if caption.lower().startswith(TAG_SHUFFLE_PREFIX):
+            # Remove the prefix and strip whitespace
+            caption = caption[len(TAG_SHUFFLE_PREFIX):].strip()
+            if should_shuffle:
+                # Shuffle tags
+                split = caption.split(delimiter)
+                random.shuffle(split)
+                caption = delimiter.join(split)
+        # Captions without prefix are kept as-is (no shuffling)
+        return caption_prefix + caption
+
     if count == 0:
-        return [caption_prefix + c for c in captions]
+        # No shuffle variations requested - still process prefix but don't shuffle
+        return [process_caption(c, should_shuffle=False) for c in captions]
 
-    def shuffle_caption(caption: str, delimiter: str = ", ") -> str:
-        split = caption.split(delimiter)
-        random.shuffle(split)
-        return delimiter.join(split)
-
-    return [caption_prefix + shuffle_caption(caption, delimiter) for caption in captions for _ in range(count)]
+    # Create multiple shuffled variations
+    result = []
+    for caption in captions:
+        for _ in range(count):
+            result.append(process_caption(caption, should_shuffle=True))
+    return result
 
 
 def bucket_suffix(key):
@@ -711,7 +747,16 @@ class DirectoryDataset:
                 captions = example['caption'][0]
             if captions is None and caption_file:
                 with open(caption_file) as f:
-                    captions = [f.read().strip()]
+                    content = f.read().strip()
+                    # Support multi-line caption files: each line is a separate caption
+                    # This allows random caption selection during training
+                    lines = [line.strip() for line in content.split('\n') if line.strip()]
+                    if len(lines) > 1:
+                        # Multi-line file: treat each line as a separate caption
+                        captions = lines
+                    else:
+                        # Single line or single caption
+                        captions = [content]
             if captions is None:
                 captions = ['']
                 logger.warning(f'Cound not find caption for {image_file}. Using empty caption.')

--- a/utils/offloading.py
+++ b/utils/offloading.py
@@ -40,7 +40,7 @@ def synchronize_device(device: torch.device):
         torch.mps.synchronize()
 
 
-def swap_weight_devices_cuda(device: torch.device, layer_to_cpu: nn.Module, layer_to_cuda: nn.Module):
+def swap_weight_devices_cuda(device: torch.device, layer_to_cpu: nn.Module, layer_to_cuda: nn.Module, skip_lora: bool = True):
     assert layer_to_cpu.__class__ == layer_to_cuda.__class__
 
     weight_swap_jobs = []
@@ -53,7 +53,9 @@ def swap_weight_devices_cuda(device: torch.device, layer_to_cpu: nn.Module, laye
 
     modules_to_cpu = {k: v for k, v in layer_to_cpu.named_modules()}
     for module_to_cuda_name, module_to_cuda in layer_to_cuda.named_modules():
-        if 'lora' in module_to_cuda_name:
+        # Skip LoRA modules when training LoRA (they need to stay on GPU for optimizer)
+        # For full-finetune, skip_lora should be False
+        if skip_lora and 'lora' in module_to_cuda_name:
             continue
         if hasattr(module_to_cuda, "weight") and module_to_cuda.weight is not None:
             module_to_cpu = modules_to_cpu.get(module_to_cuda_name, None)
@@ -86,34 +88,43 @@ def swap_weight_devices_cuda(device: torch.device, layer_to_cpu: nn.Module, laye
     torch.cuda.current_stream().synchronize()  # this prevents the illegal loss value
 
 
-def swap_weight_devices_no_cuda(device: torch.device, layer_to_cpu: nn.Module, layer_to_cuda: nn.Module):
+def swap_weight_devices_no_cuda(device: torch.device, layer_to_cpu: nn.Module, layer_to_cuda: nn.Module, skip_lora: bool = True):
     """
     not tested
     """
     assert layer_to_cpu.__class__ == layer_to_cuda.__class__
 
     weight_swap_jobs = []
-    for module_to_cpu, module_to_cuda in zip(layer_to_cpu.modules(), layer_to_cuda.modules()):
-        if hasattr(module_to_cpu, "weight") and module_to_cpu.weight is not None:
-            weight_swap_jobs.append((module_to_cpu, module_to_cuda, module_to_cpu.weight.data, module_to_cuda.weight.data))
+    modules_to_cpu = {k: v for k, v in layer_to_cpu.named_modules()}
+    for module_to_cuda_name, module_to_cuda in layer_to_cuda.named_modules():
+        # Skip LoRA modules when training LoRA (they need to stay on GPU for optimizer)
+        # For full-finetune, skip_lora should be False
+        if skip_lora and 'lora' in module_to_cuda_name:
+            continue
+        if hasattr(module_to_cuda, "weight") and module_to_cuda.weight is not None:
+            module_to_cpu = modules_to_cpu.get(module_to_cuda_name, None)
+            if module_to_cpu is not None and module_to_cpu.weight.shape == module_to_cuda.weight.shape:
+                weight_swap_jobs.append((module_to_cpu, module_to_cuda, module_to_cpu.weight.data, module_to_cuda.weight.data))
 
     # device to cpu
     for module_to_cpu, module_to_cuda, cuda_data_view, cpu_data_view in weight_swap_jobs:
         module_to_cpu.weight.data = cuda_data_view.data.to("cpu", non_blocking=True)
 
-    synchronize_device()
+    synchronize_device(device)
 
     # cpu to device
     for module_to_cpu, module_to_cuda, cuda_data_view, cpu_data_view in weight_swap_jobs:
         cuda_data_view.copy_(module_to_cuda.weight.data, non_blocking=True)
         module_to_cuda.weight.data = cuda_data_view
 
-    synchronize_device()
+    synchronize_device(device)
 
 
-def weights_to_device(layer: nn.Module, device: torch.device):
+def weights_to_device(layer: nn.Module, device: torch.device, skip_lora: bool = True):
     for name, module in layer.named_modules():
-        if device.type == 'cpu' and 'lora' in name:
+        # Skip LoRA modules when moving to CPU (they need to stay on GPU for optimizer)
+        # For full-finetune, skip_lora should be False
+        if skip_lora and device.type == 'cpu' and 'lora' in name:
             continue
         if hasattr(module, "weight") and module.weight is not None:
             module.weight.data = module.weight.data.to(device, non_blocking=True)
@@ -124,7 +135,7 @@ class Offloader:
     common offloading class
     """
 
-    def __init__(self, block_type: str, blocks: list[nn.Module], num_blocks: int, blocks_to_swap: int, device: torch.device, debug: bool = False):
+    def __init__(self, block_type: str, blocks: list[nn.Module], num_blocks: int, blocks_to_swap: int, device: torch.device, debug: bool = False, skip_lora: bool = True):
         self.block_type = block_type
         self.blocks = blocks
         self.num_blocks = num_blocks
@@ -132,6 +143,9 @@ class Offloader:
         self.blocks_to_swap_tmp = None
         self.device = device
         self.debug = debug
+        # skip_lora=True for LoRA training (keep LoRA weights on GPU)
+        # skip_lora=False for full-finetune (swap all weights)
+        self.skip_lora = skip_lora
 
         self.thread_pool = ThreadPoolExecutor(max_workers=1)
         self.futures = {}
@@ -139,9 +153,9 @@ class Offloader:
 
     def swap_weight_devices(self, block_to_cpu: nn.Module, block_to_cuda: nn.Module):
         if self.cuda_available:
-            swap_weight_devices_cuda(self.device, block_to_cpu, block_to_cuda)
+            swap_weight_devices_cuda(self.device, block_to_cpu, block_to_cuda, skip_lora=self.skip_lora)
         else:
-            swap_weight_devices_no_cuda(self.device, block_to_cpu, block_to_cuda)
+            swap_weight_devices_no_cuda(self.device, block_to_cpu, block_to_cuda, skip_lora=self.skip_lora)
 
     def _submit_move_blocks(self, block_idx_to_cpu, block_idx_to_cuda):
         def move_blocks(bidx_to_cpu, block_to_cpu, bidx_to_cuda, block_to_cuda):
@@ -196,8 +210,9 @@ class ModelOffloader(Offloader):
         device: torch.device,
         reentrant_activation_checkpointing: bool,
         debug: bool = False,
+        skip_lora: bool = True,
     ):
-        super().__init__(block_type, blocks, num_blocks, blocks_to_swap, device, debug)
+        super().__init__(block_type, blocks, num_blocks, blocks_to_swap, device, debug, skip_lora=skip_lora)
 
         self.supports_backward = supports_backward
         self.forward_only = not supports_backward  # forward only offloading: can be changed to True for inference
@@ -265,11 +280,11 @@ class ModelOffloader(Offloader):
 
         for b in self.blocks[0 : self.num_blocks - self.blocks_to_swap]:
             b.to(self.device)
-            weights_to_device(b, self.device)  # make sure weights are on device
+            weights_to_device(b, self.device, skip_lora=self.skip_lora)  # make sure weights are on device
 
         for b in self.blocks[self.num_blocks - self.blocks_to_swap :]:
             b.to(self.device)  # move block to device first
-            weights_to_device(b, torch.device('cpu'))  # make sure weights are on cpu
+            weights_to_device(b, torch.device('cpu'), skip_lora=self.skip_lora)  # make sure weights are on cpu
 
         synchronize_device(self.device)
         clean_memory_on_device(self.device)

--- a/utils/saver.py
+++ b/utils/saver.py
@@ -54,6 +54,9 @@ class Saver:
         self.train_dataloader = train_dataloader
         self.model_engine = model_engine
         self.pipeline_model = pipeline_model
+        # Maximum number of checkpoints to keep (0 = unlimited)
+        self.max_checkpoints = config.get('max_checkpoints', 0)
+        self.checkpoint_history = []  # Track checkpoint directories for cleanup
 
     def save_adapter(self, name):
         dp_id = self.model_engine.grid.get_data_parallel_rank()
@@ -114,6 +117,9 @@ class Saver:
             self.save_adapter(name)
         else:
             self.save_full_model(name)
+        # Cleanup old saves if max_checkpoints is set
+        if self.max_checkpoints > 0 and is_main_process():
+            self._cleanup_old_checkpoints()
 
     def save_checkpoint(self, step, examples):
         self.model_engine.save_checkpoint(
@@ -126,6 +132,9 @@ class Saver:
             save_latest=True,
             exclude_frozen_parameters=True
         )
+        # Track and cleanup old checkpoints if max_checkpoints is set
+        if self.max_checkpoints > 0 and is_main_process():
+            self._cleanup_old_checkpoints()
 
     def process_epoch(self, epoch, step, examples):
         checkpointed, saved = False, False
@@ -175,3 +184,64 @@ class Saver:
             sys.exit()
 
         return checkpointed, saved
+
+    def _cleanup_old_checkpoints(self):
+        """Remove old checkpoints if we exceed max_checkpoints limit.
+
+        This handles both:
+        - global_step* directories (DeepSpeed checkpoints for resume)
+        - epoch* directories (saved model weights)
+        - step* directories (if save_every_n_steps is used)
+        """
+        if self.max_checkpoints <= 0:
+            return
+
+        import re
+
+        def extract_number(name, prefix):
+            """Extract number from directory name like 'epoch5' -> 5, 'global_step1000' -> 1000"""
+            match = re.search(rf'{prefix}(\d+)', name)
+            return int(match.group(1)) if match else 0
+
+        # Find all checkpoint directories (DeepSpeed uses global_step* pattern)
+        checkpoint_dirs = sorted(
+            [d for d in self.save_root.iterdir() if d.is_dir() and d.name.startswith('global_step')],
+            key=lambda x: extract_number(x.name, 'global_step')  # Sort by step number
+        )
+
+        # Remove oldest checkpoints if we exceed the limit
+        while len(checkpoint_dirs) > self.max_checkpoints:
+            oldest = checkpoint_dirs.pop(0)
+            try:
+                shutil.rmtree(oldest)
+                logger.info(f'Removed old checkpoint: {oldest}')
+            except Exception as e:
+                logger.warning(f'Failed to remove old checkpoint {oldest}: {e}')
+
+        # Also cleanup epoch* directories (saved model weights)
+        epoch_dirs = sorted(
+            [d for d in self.save_root.iterdir() if d.is_dir() and d.name.startswith('epoch')],
+            key=lambda x: extract_number(x.name, 'epoch')  # Sort by epoch number
+        )
+
+        while len(epoch_dirs) > self.max_checkpoints:
+            oldest = epoch_dirs.pop(0)
+            try:
+                shutil.rmtree(oldest)
+                logger.info(f'Removed old epoch save: {oldest}')
+            except Exception as e:
+                logger.warning(f'Failed to remove old epoch save {oldest}: {e}')
+
+        # Also cleanup step* directories (if save_every_n_steps is used)
+        step_dirs = sorted(
+            [d for d in self.save_root.iterdir() if d.is_dir() and d.name.startswith('step')],
+            key=lambda x: extract_number(x.name, 'step')  # Sort by step number
+        )
+
+        while len(step_dirs) > self.max_checkpoints:
+            oldest = step_dirs.pop(0)
+            try:
+                shutil.rmtree(oldest)
+                logger.info(f'Removed old step save: {oldest}')
+            except Exception as e:
+                logger.warning(f'Failed to remove old step save {oldest}: {e}')


### PR DESCRIPTION
Hi @tdrussell
Here is the description of my change for support Anima model
1. Summary
- Add Anima model support (LoRA and full-finetune training)
- Add `max_checkpoints` config option to automatically delete old checkpoints

2. Changes

a. Anima Model Support
- Added `models/anima.py` - Anima pipeline with dual text encoders (Qwen3 + T5)
- Added `models/anima_modeling.py` - MiniTrainDIT with LLMAdapter architecture
- Support for both LoRA and full-finetune training modes
- Options: `freeze_llm_adapter`, `llm_adapter_lr`, `load_to_cuda`
- Compatible with Qwen NF4 quantization for lower VRAM

b.  Checkpoint Management
- Added `max_checkpoints` option in `utils/saver.py`
- Automatically deletes oldest checkpoints when limit exceeded
- Applies to: `global_step*`, `epoch*`, `step*` directories

Note: I checked for training LORA and full finetune model and it work correctly. If you have any question feel free to ask.