### PR TITLE
Add deepspeed optimizers, prodigy, + LR schedulers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # diffusion-pipe
 A pipeline parallel training script for diffusion models.
 
-Models supported: SDXL, Flux, LTX-Video, HunyuanVideo (t2v), Cosmos, Lumina Image 2.0, Wan2.1 (t2v and i2v), Chroma, HiDream, Stable Diffusion 3, Cosmos-Predict2, OmniGen2, Flux Kontext, Wan2.2, Qwen-Image, Qwen-Image-Edit, HunyuanImage-2.1, AuraFlow, Z-Image, HunyuanVideo-1.5, Flux 2 (Dev and Klein).
+Models supported: SDXL, Flux, LTX-Video, HunyuanVideo (t2v), Cosmos, Lumina Image 2.0, Wan2.1 (t2v and i2v), Chroma, HiDream, Stable Diffusion 3, Cosmos-Predict2, OmniGen2, Flux Kontext, Wan2.2, Qwen-Image, Qwen-Image-Edit, HunyuanImage-2.1, AuraFlow, Z-Image, HunyuanVideo-1.5, Flux 2 (Dev and Klein), Anima.
 
 ## Features
 - Pipeline parallelism, for training models larger than can fit on a single GPU
@@ -13,6 +13,8 @@ Models supported: SDXL, Flux, LTX-Video, HunyuanVideo (t2v), Cosmos, Lumina Imag
 - Easily add new models by implementing a single subclass
 
 ## Recent changes
+- 2026-02-04
+  - Support Anima.
 - 2026-01-16
   - Support Flux 2, both Dev and Klein.
   - Updated DeepSpeed version. Should probably update all requirements: `pip install -r requirements.txt -U`.
@@ -37,9 +39,6 @@ Models supported: SDXL, Flux, LTX-Video, HunyuanVideo (t2v), Cosmos, Lumina Imag
   - Support Qwen-Image-Edit. Make sure to update dependencies. You will need the latest Diffusers.
 - 2025-08-07
   - Fix Flux training error caused by a breaking change in Diffusers. Make sure to update requirements.
-- 2025-08-06
-  - Support Qwen-Image.
-  - Slight speed improvement to Automagic optimizer.
 
 ## Windows support
 It will be difficult or impossible to make training work on native Windows. This is because Deepspeed only has [partial Windows support](https://github.com/microsoft/DeepSpeed/blob/master/blogs/windows/08-2024/README.md). Deepspeed is a hard requirement because the entire training script is built around Deepspeed pipeline parallelism. However, it will work on Windows Subsystem for Linux, specifically WSL 2. If you must use Windows I recommend trying WSL 2.
@@ -95,7 +94,7 @@ Edit the paths above for your conda environment.
 git pull
 git submodule update
 ```
-This project uses git submodules. If a new submodule has been added, you need to run ```git submodule update``` once after pulling in order to clone the new submodule. This only needs to be done once when a new submodule is added.
+Make sure to run `git submodule update` in case any submodule has been updated to a new commit.
 
 ### Updating dependencies
 Most dependencies are intentionally left unpinned in the requirements.txt file. If you want to update them to the latest version, you can run ```pip install -r requirements.txt -U```.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # diffusion-pipe
 A pipeline parallel training script for diffusion models.
 
-Models supported: SDXL, Flux, LTX-Video, HunyuanVideo (t2v), Cosmos, Lumina Image 2.0, Wan2.1 (t2v and i2v), Chroma, HiDream, Stable Diffusion 3, Cosmos-Predict2, OmniGen2, Flux Kontext, Wan2.2, Qwen-Image, Qwen-Image-Edit, HunyuanImage-2.1, AuraFlow, Z-Image, HunyuanVideo-1.5, Flux 2 (Dev and Klein), Anima.
+Models supported: SDXL, Flux, LTX-Video, HunyuanVideo (t2v), Cosmos, Lumina Image 2.0, Wan2.1 (t2v and i2v), Chroma, HiDream, Stable Diffusion 3, Cosmos-Predict2, OmniGen2, Flux Kontext, Wan2.2, Qwen-Image, Qwen-Image-Edit, HunyuanImage-2.1, AuraFlow, Z-Image, HunyuanVideo-1.5, Flux 2 (Dev and Klein).
 
 ## Features
 - Pipeline parallelism, for training models larger than can fit on a single GPU
@@ -13,8 +13,6 @@ Models supported: SDXL, Flux, LTX-Video, HunyuanVideo (t2v), Cosmos, Lumina Imag
 - Easily add new models by implementing a single subclass
 
 ## Recent changes
-- 2026-02-04
-  - Support Anima.
 - 2026-01-16
   - Support Flux 2, both Dev and Klein.
   - Updated DeepSpeed version. Should probably update all requirements: `pip install -r requirements.txt -U`.
@@ -39,6 +37,9 @@ Models supported: SDXL, Flux, LTX-Video, HunyuanVideo (t2v), Cosmos, Lumina Imag
   - Support Qwen-Image-Edit. Make sure to update dependencies. You will need the latest Diffusers.
 - 2025-08-07
   - Fix Flux training error caused by a breaking change in Diffusers. Make sure to update requirements.
+- 2025-08-06
+  - Support Qwen-Image.
+  - Slight speed improvement to Automagic optimizer.
 
 ## Windows support
 It will be difficult or impossible to make training work on native Windows. This is because Deepspeed only has [partial Windows support](https://github.com/microsoft/DeepSpeed/blob/master/blogs/windows/08-2024/README.md). Deepspeed is a hard requirement because the entire training script is built around Deepspeed pipeline parallelism. However, it will work on Windows Subsystem for Linux, specifically WSL 2. If you must use Windows I recommend trying WSL 2.
@@ -80,11 +81,6 @@ pip install -r requirements.txt
 pip install flash-attn
 ```
 
-### Fused AdamW
-If you plan to use the `fused_adamw` optimizer, you must set the `CUDA_HOME` environment variable to the path of your CUDA toolkit installation. This is required for DeepSpeed to compile the custom CUDA kernel.
-```
-export CUDA_HOME=/usr/local/cuda-12.8
-
 ### Cosmos requirements
 NVIDIA Cosmos (the original Cosmos video model, not Cosmos-Predict2) additionally requires TransformerEngine.
 
@@ -99,7 +95,7 @@ Edit the paths above for your conda environment.
 git pull
 git submodule update
 ```
-Make sure to run `git submodule update` in case any submodule has been updated to a new commit.
+This project uses git submodules. If a new submodule has been added, you need to run ```git submodule update``` once after pulling in order to clone the new submodule. This only needs to be done once when a new submodule is added.
 
 ### Updating dependencies
 Most dependencies are intentionally left unpinned in the requirements.txt file. If you want to update them to the latest version, you can run ```pip install -r requirements.txt -U```.

--- a/README.md
+++ b/README.md
@@ -80,6 +80,11 @@ pip install -r requirements.txt
 pip install flash-attn
 ```
 
+### Fused AdamW
+If you plan to use the `fused_adamw` optimizer, you must set the `CUDA_HOME` environment variable to the path of your CUDA toolkit installation. This is required for DeepSpeed to compile the custom CUDA kernel.
+```
+export CUDA_HOME=/usr/local/cuda-12.8
+
 ### Cosmos requirements
 NVIDIA Cosmos (the original Cosmos video model, not Cosmos-Predict2) additionally requires TransformerEngine.
 

--- a/examples/main_example.toml
+++ b/examples/main_example.toml
@@ -31,7 +31,8 @@ warmup_steps = 100
 # Force the learning rate to be this value, regardless of what the optimizer or anything else says.
 # Can be used to change learning rate even when resuming from checkpoint.
 #force_constant_lr = 1e-5
-# Can be 'constant' or 'linear'. If unset, will default to 'constant', i.e. no LR scheduler.
+# Can be 'constant', 'linear', 'cosine', 'cosine_with_restarts', 'onecycle'.
+# If unset, will default to 'constant', i.e. no LR scheduler.
 #lr_scheduler = 'linear'
 
 # Block swapping is supported for Wan, HunyuanVideo, Flux, and Chroma. This value controls the number
@@ -144,6 +145,21 @@ dtype = 'bfloat16'
 #]
 
 [optimizer]
+# Supported optimizers:
+# - adamw: standard AdamW
+# - fused_adamw: fast CUDA-fused AdamW from DeepSpeed (requires CUDA_HOME)
+# - adamw8bit: 8-bit AdamW from bitsandbytes
+# - adamw_optimi: AdamW from optimi library (supports Kahan summation)
+# - stableadamw: StableAdamW from optimi library
+# - sgd: standard SGD
+# - adamw8bitkahan: local implementation of 8-bit AdamW with Kahan summation
+# - offload: CPU offloaded optimizer (using torchao)
+# - automagic: Automagic optimizer (from AI-Toolkit)
+# - prodigy: Prodigy optimizer (8-bit)
+# - deepspeed_adamw: DeepSpeed CPU Adam
+# - genericoptim: Generic optimizer wrapper
+# - Any optimizer from pytorch-optimizer library (dynamically loaded)
+
 # AdamW from the optimi library is a good default since it automatically uses Kahan summation when training bfloat16 weights.
 # Look at train.py for other options. You could also easily edit the file and add your own.
 type = 'adamw_optimi'
@@ -167,12 +183,22 @@ eps = 1e-8
 # type = 'automagic'
 # weight_decay = 0.01
 
-# Any optimizer not explicitly supported will be dynamically loaded from the pytorch-optimizer library.
 # [optimizer]
-# type = 'Prodigy'
-# lr = 1
+# type = 'fused_adamw'
+# lr = 2e-5
 # betas = [0.9, 0.99]
 # weight_decay = 0.01
+# # You MUST set CUDA_HOME environment variable to your CUDA toolkit path for this to work.
+# # e.g. export CUDA_HOME=/usr/local/cuda-12.8
+
+# Prodigy optimizer (from pytorch-optimizer).
+# Default config based on prodigy authors diffusion model config example.
+# [optimizer]
+# type = "prodigy"
+# lr = 1
+# weight_decay = 0.01
+# use_bias_correction = true
+# safeguard_warmup = true
 
 [monitoring]
 # Set to true and fill in these fields to enable wandb

--- a/optimizers/prodigy_8bit.py
+++ b/optimizers/prodigy_8bit.py
@@ -1,0 +1,303 @@
+import math
+import torch
+import torch.distributed as dist
+from torch.optim import Optimizer
+from optimizers.optimizer_utils import copy_stochastic, Auto8bitTensor, stochastic_grad_accummulation
+
+
+class Prodigy8bit(Optimizer):
+    r"""
+    Implements Adam with Prodigy step-sizes.
+    Handles stochastic rounding for various precisions as well as stochastic gradient accumulation.
+    Stores state in 8bit for memory savings.
+    Leave LR set to 1 unless you encounter instability.
+
+    Arguments:
+        params (iterable):
+            Iterable of parameters to optimize or dicts defining parameter groups.
+        lr (float):
+            Learning rate adjustment parameter. Increases or decreases the Prodigy learning rate.
+        betas (Tuple[float, float], optional): coefficients used for computing
+            running averages of gradient and its square (default: (0.9, 0.999))
+        beta3 (float):
+            coefficients for computing the Prodidy stepsize using running averages.
+            If set to None, uses the value of square root of beta2 (default: None).
+        eps (float):
+            Term added to the denominator outside of the root operation to improve numerical stability. (default: 1e-8).
+        weight_decay (float):
+            Weight decay, i.e. a L2 penalty (default: 0).
+        decouple (boolean):
+            Use AdamW style decoupled weight decay
+        use_bias_correction (boolean):
+            Turn on Adam's bias correction. Off by default.
+        safeguard_warmup (boolean):
+            Remove lr from the denominator of D estimate to avoid issues during warm-up stage. Off by default.
+        d0 (float):
+            Initial D estimate for D-adaptation (default 1e-6). Rarely needs changing.
+        d_coef (float):
+            Coefficient in the expression for the estimate of d (default 1.0).
+            Values such as 0.5 and 2.0 typically work as well. 
+            Changing this parameter is the preferred way to tune the method.
+        growth_rate (float):
+            prevent the D estimate from growing faster than this multiplicative rate.
+            Default is inf, for unrestricted. Values like 1.02 give a kind of learning
+            rate warmup effect.
+        fsdp_in_use (bool):
+            If you're using sharded parameters, this should be set to True. The optimizer
+            will attempt to auto-detect this, but if you're using an implementation other
+            than PyTorch's builtin version, the auto-detection won't work.
+    """
+
+    def __init__(self, params, lr=1.0,
+                 betas=(0.9, 0.999), beta3=None,
+                 eps=1e-8, weight_decay=0, decouple=True,
+                 use_bias_correction=False, safeguard_warmup=False,
+                 d0=1e-6, d_coef=1.0, growth_rate=float('inf'),
+                 fsdp_in_use=False):
+        if not 0.0 < d0:
+            raise ValueError("Invalid d0 value: {}".format(d0))
+        if not 0.0 < lr:
+            raise ValueError("Invalid learning rate: {}".format(lr))
+        if not 0.0 < eps:
+            raise ValueError("Invalid epsilon value: {}".format(eps))
+        if not 0.0 <= betas[0] < 1.0:
+            raise ValueError(
+                "Invalid beta parameter at index 0: {}".format(betas[0]))
+        if not 0.0 <= betas[1] < 1.0:
+            raise ValueError(
+                "Invalid beta parameter at index 1: {}".format(betas[1]))
+
+        if decouple and weight_decay > 0:
+            print(f"Using decoupled weight decay")
+
+        defaults = dict(lr=lr, betas=betas, beta3=beta3,
+                        eps=eps, weight_decay=weight_decay,
+                        d=d0, d0=d0, d_max=d0,
+                        d_numerator=0.0, d_coef=d_coef,
+                        k=0, growth_rate=growth_rate,
+                        use_bias_correction=use_bias_correction,
+                        decouple=decouple, safeguard_warmup=safeguard_warmup,
+                        fsdp_in_use=fsdp_in_use)
+        self.d0 = d0
+        super(Prodigy8bit, self).__init__(params, defaults)
+
+        self.is_stochastic_rounding_accumulation = False
+
+        # setup stochastic grad accum hooks
+        for group in self.param_groups:
+            for param in group['params']:
+                if param.requires_grad and param.dtype != torch.float32:
+                    self.is_stochastic_rounding_accumulation = True
+                    param.register_post_accumulate_grad_hook(
+                        stochastic_grad_accummulation
+                    )
+
+    @property
+    def supports_memory_efficient_fp16(self):
+        return False
+
+    @property
+    def supports_flat_params(self):
+        return True
+
+    def step_hook(self):
+        if not self.is_stochastic_rounding_accumulation:
+            return
+        # copy over stochastically rounded grads
+        for group in self.param_groups:
+            for param in group['params']:
+                if param.requires_grad and hasattr(param, "_accum_grad"):
+                    param.grad = param._accum_grad
+                    del param._accum_grad
+
+    @torch.no_grad()
+    def step(self, closure=None):
+        """Performs a single optimization step.
+
+        Arguments:
+            closure (callable, optional): A closure that reevaluates the model
+                and returns the loss.
+        """
+        # call pre step
+        self.step_hook()
+        loss = None
+        if closure is not None:
+            loss = closure()
+
+        d_denom = 0.0
+
+        group = self.param_groups[0]
+        use_bias_correction = group['use_bias_correction']
+        beta1, beta2 = group['betas']
+        beta3 = group['beta3']
+        if beta3 is None:
+            beta3 = math.sqrt(beta2)
+        k = group['k']
+
+        d = group['d']
+        d_max = group['d_max']
+        d_coef = group['d_coef']
+        lr = max(group['lr'] for group in self.param_groups)
+
+        if use_bias_correction:
+            bias_correction = ((1 - beta2**(k+1))**0.5) / (1 - beta1**(k+1))
+        else:
+            bias_correction = 1
+
+        dlr = d*lr*bias_correction
+
+        growth_rate = group['growth_rate']
+        decouple = group['decouple']
+        fsdp_in_use = group['fsdp_in_use']
+
+        d_numerator = group['d_numerator']
+        d_numerator *= beta3
+
+        for group in self.param_groups:
+            decay = group['weight_decay']
+            k = group['k']
+            eps = group['eps']
+            group_lr = group['lr']
+            d0 = group['d0']
+            safeguard_warmup = group['safeguard_warmup']
+
+            if group_lr not in [lr, 0.0]:
+                raise RuntimeError(
+                    f"Setting different lr values in different parameter groups is only supported for values of 0")
+
+            for p in group['params']:
+                if p.grad is None:
+                    continue
+                if hasattr(p, "_fsdp_flattened"):
+                    fsdp_in_use = True
+
+                grad = p.grad.data.to(torch.float32)
+                p_fp32 = p.clone().to(torch.float32)
+
+                # Apply weight decay (coupled variant)
+                if decay != 0 and not decouple:
+                    grad.add_(p_fp32.data, alpha=decay)
+
+                state = self.state[p]
+
+                # State initialization
+                if 'step' not in state:
+                    state['step'] = 0
+                    state['s'] = Auto8bitTensor(
+                        torch.zeros_like(p_fp32.data).detach())
+                    state['p0'] = Auto8bitTensor(p_fp32.detach().clone())
+                    # Exponential moving average of gradient values
+                    state['exp_avg'] = Auto8bitTensor(
+                        torch.zeros_like(p_fp32.data).detach())
+                    # Exponential moving average of squared gradient values
+                    state['exp_avg_sq'] = Auto8bitTensor(
+                        torch.zeros_like(p_fp32.data).detach())
+
+                exp_avg = state['exp_avg'].to(torch.float32)
+                exp_avg_sq = state['exp_avg_sq'].to(torch.float32)
+
+                s = state['s'].to(torch.float32)
+                p0 = state['p0'].to(torch.float32)
+
+                if group_lr > 0.0:
+                    # we use d / d0 instead of just d to avoid getting values that are too small
+                    d_numerator += (d / d0) * dlr * torch.dot(grad.flatten(),
+                                                              (p0.data - p_fp32.data).flatten()).item()
+
+                    # Adam EMA updates
+                    exp_avg.mul_(beta1).add_(grad, alpha=d * (1-beta1))
+                    exp_avg_sq.mul_(beta2).addcmul_(
+                        grad, grad, value=d * d * (1-beta2))
+
+                    if safeguard_warmup:
+                        s.mul_(beta3).add_(grad, alpha=((d / d0) * d))
+                    else:
+                        s.mul_(beta3).add_(grad, alpha=((d / d0) * dlr))
+                    d_denom += s.abs().sum().item()
+
+                # update state with stochastic rounding
+                state['exp_avg'] = Auto8bitTensor(exp_avg)
+                state['exp_avg_sq'] = Auto8bitTensor(exp_avg_sq)
+                state['s'] = Auto8bitTensor(s)
+                state['p0'] = Auto8bitTensor(p0)
+
+        d_hat = d
+
+        # if we have not done any progres, return
+        # if we have any gradients available, will have d_denom > 0 (unless \|g\|=0)
+        if d_denom == 0:
+            return loss
+
+        if lr > 0.0:
+            if fsdp_in_use:
+                dist_tensor = torch.zeros(2).cuda()
+                dist_tensor[0] = d_numerator
+                dist_tensor[1] = d_denom
+                dist.all_reduce(dist_tensor, op=dist.ReduceOp.SUM)
+                global_d_numerator = dist_tensor[0]
+                global_d_denom = dist_tensor[1]
+            else:
+                global_d_numerator = d_numerator
+                global_d_denom = d_denom
+
+            d_hat = d_coef * global_d_numerator / global_d_denom
+            if d == group['d0']:
+                d = max(d, d_hat)
+            d_max = max(d_max, d_hat)
+            d = min(d_max, d * growth_rate)
+
+        for group in self.param_groups:
+            group['d_numerator'] = global_d_numerator
+            group['d_denom'] = global_d_denom
+            group['d'] = d
+            group['d_max'] = d_max
+            group['d_hat'] = d_hat
+
+            decay = group['weight_decay']
+            k = group['k']
+            eps = group['eps']
+
+            for p in group['params']:
+                if p.grad is None:
+                    continue
+                grad = p.grad.data.to(torch.float32)
+                p_fp32 = p.clone().to(torch.float32)
+
+                state = self.state[p]
+
+                exp_avg = state['exp_avg'].to(torch.float32)
+                exp_avg_sq = state['exp_avg_sq'].to(torch.float32)
+
+                state['step'] += 1
+
+                denom = exp_avg_sq.sqrt().add_(d * eps)
+
+                # Apply weight decay (decoupled variant)
+                if decay != 0 and decouple:
+                    p_fp32.data.add_(p_fp32.data, alpha=-decay * dlr)
+
+                # Take step
+                p_fp32.data.addcdiv_(exp_avg, denom, value=-dlr)
+                # apply stochastic rounding
+                copy_stochastic(p.data, p_fp32.data)
+
+            group['k'] = k + 1
+
+        return loss
+
+    def get_avg_learning_rate(self):
+        """Return the current effective learning rate (d * lr * bias_correction) for logging."""
+        if not self.param_groups:
+            return 0.0
+        lrs = []
+        for group in self.param_groups:
+            k = group['k']
+            use_bias_correction = group['use_bias_correction']
+            beta1, beta2 = group['betas']
+            if use_bias_correction and k > 0:
+                bias_correction = ((1 - beta2 ** (k + 1)) ** 0.5) / (1 - beta1 ** (k + 1))
+            else:
+                bias_correction = 1
+            lrs.append(group['d'] * group['lr'] * bias_correction)
+        return sum(lrs) / len(lrs)
+

--- a/train.py
+++ b/train.py
@@ -1,5 +1,4 @@
 import argparse
-import logging
 import os
 import signal
 import wandb
@@ -649,6 +648,7 @@ if __name__ == '__main__':
             # klass = deepspeed.ops.adam.FusedAdam
             klass = torch.optim.AdamW
         elif optim_type_lower == 'fused_adamw':
+            # Make sure to set CUDA_HOME to the path of your CUDA toolkit installation, and that it is the same version as pytorch.
             klass = deepspeed.ops.adam.FusedAdam
         elif optim_type_lower == 'adamw8bit':
             import bitsandbytes
@@ -806,7 +806,7 @@ if __name__ == '__main__':
     train_dataloader = dataset_util.PipelineDataLoader(train_data, model_engine, model_engine.gradient_accumulation_steps(), model)
     steps_per_epoch = len(train_dataloader) // model_engine.gradient_accumulation_steps()
 
-    print(f'oooooooooooooooooooooo steps_per_epoch: ', steps_per_epoch)
+    print(f'steps_per_epoch: ', steps_per_epoch)
 
 
     scheduler_type = config.get('lr_scheduler', 'constant')

--- a/train.py
+++ b/train.py
@@ -1,5 +1,7 @@
 import argparse
+import logging
 import os
+import signal
 import wandb
 # Disable comfy_kitchen during training to avoid autograd errors
 import sys
@@ -38,6 +40,21 @@ from utils.pipeline import ManualPipelineModule
 mp.current_process().authkey = b'afsaskgfdjh4'
 
 wandb_enable = False
+
+# Path for signal-triggered checkpoint: when SIGUSR1 is received, we touch this file
+# and the saver's process_step (same as checkpoint_every_n_minutes) will save on next step.
+_checkpoint_signal_path = None
+
+
+def _handle_checkpoint_signal(signum, frame):
+    """On SIGUSR1, create the 'save' file so the saver will checkpoint on the next step."""
+    global _checkpoint_signal_path
+    if _checkpoint_signal_path:
+        try:
+            Path(_checkpoint_signal_path).touch()
+        except Exception:
+            pass
+
 
 TIMESTEP_QUANTILES_FOR_EVAL = [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9]
 
@@ -631,6 +648,8 @@ if __name__ == '__main__':
             # when Deepspeed tries to build the fused Adam extension.
             # klass = deepspeed.ops.adam.FusedAdam
             klass = torch.optim.AdamW
+        elif optim_type_lower == 'fused_adamw':
+            klass = deepspeed.ops.adam.FusedAdam
         elif optim_type_lower == 'adamw8bit':
             import bitsandbytes
             klass = bitsandbytes.optim.AdamW8bit
@@ -646,13 +665,18 @@ if __name__ == '__main__':
             from optimizers import adamw_8bit
             klass = adamw_8bit.AdamW8bitKahan
         elif optim_type_lower == 'offload':
-            from torchao.prototype.low_bit_optim import CPUOffloadOptimizer
+            from torchao.optim.cpu_offload import CPUOffloadOptimizer
             klass = CPUOffloadOptimizer
             args.append(torch.optim.AdamW)
             kwargs['fused'] = True
         elif optim_type_lower == 'automagic':
             from optimizers import automagic
             klass = automagic.Automagic
+        elif optim_type_lower == 'prodigy':
+            from optimizers import prodigy_8bit
+            klass = prodigy_8bit.Prodigy8bit
+        elif optim_type_lower == 'deepspeed_adamw':
+            klass = deepspeed.ops.adam.DeepSpeedCPUAdam
         elif optim_type_lower == 'genericoptim':
             from optimizers import generic_optim
             klass = generic_optim.GenericOptim
@@ -782,11 +806,40 @@ if __name__ == '__main__':
     train_dataloader = dataset_util.PipelineDataLoader(train_data, model_engine, model_engine.gradient_accumulation_steps(), model)
     steps_per_epoch = len(train_dataloader) // model_engine.gradient_accumulation_steps()
 
+    print(f'oooooooooooooooooooooo steps_per_epoch: ', steps_per_epoch)
+
+
     scheduler_type = config.get('lr_scheduler', 'constant')
     if scheduler_type == 'constant':
         lr_scheduler = torch.optim.lr_scheduler.ConstantLR(optimizer, factor=1.0)
     elif scheduler_type == 'linear':
         lr_scheduler = torch.optim.lr_scheduler.LinearLR(optimizer, start_factor=1.0, end_factor=0.0, total_iters=config['epochs'] * steps_per_epoch)
+    elif scheduler_type == 'cosine':
+        lr_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(
+            optimizer,
+            T_max=config['epochs'] * steps_per_epoch,
+            eta_min=config.get('lr_scheduler_eta_min', 0)
+        )
+    elif scheduler_type == 'cosine_with_restarts':
+        # T_0 is the number of steps until the first restart
+        # T_mult is the factor by which T_0 increases after each restart (default 1 = fixed period)
+        lr_scheduler = torch.optim.lr_scheduler.CosineAnnealingWarmRestarts(
+            optimizer,
+            T_0=config.get('lr_scheduler_t0', steps_per_epoch),
+            T_mult=config.get('lr_scheduler_t_mult', 1),
+            eta_min=config.get('lr_scheduler_eta_min', 0)
+        )
+    elif scheduler_type == 'onecycle':
+        if config['warmup_steps'] > 0:
+            print(f'cannot use warmup_steps with onecycle scheduler')
+            exit()
+        lr_scheduler = torch.optim.lr_scheduler.OneCycleLR(
+            optimizer,
+            max_lr=config.get('lr_max_onecycle', 1e-3),
+            total_steps=config['epochs'] * steps_per_epoch,
+            pct_start=config.get('lr_scheduler_pct_start', 0.3),
+            anneal_strategy=config.get('lr_scheduler_anneal_strategy', 'cos'),
+        )
     else:
         raise NotImplementedError(f'Unknown lr_scheduler: {scheduler_type}')
     if config['warmup_steps'] > 0:
@@ -837,6 +890,10 @@ if __name__ == '__main__':
     epoch = train_dataloader.epoch
     tb_writer = SummaryWriter(log_dir=run_dir) if is_main_process() else None
     saver = utils.saver.Saver(args, config, is_adapter, run_dir, model, train_dataloader, model_engine, pipeline_model)
+
+    # Allow checkpoint-on-signal (SIGUSR1): same behavior as checkpoint_every_n_minutes
+    _checkpoint_signal_path = str(Path(run_dir) / 'save')
+    signal.signal(signal.SIGUSR1, _handle_checkpoint_signal)
 
     disable_block_swap_for_eval = config.get('disable_block_swap_for_eval', False)
     if config['eval_before_first_step'] and not resume_from_checkpoint:


### PR DESCRIPTION
Thought I would push this up in case anyone else finds it useful... added several LR schedulers, prodigy optimizer stolen from ai-toolkit, + options for the deepspeed built ins. 

Deepspeed optimizers requre setting CUDA_HOME in your environment variables, and don't work with multiple GPUs. It does seem to save vram though. 

Also, generate a checkpoint if we get a USR1 signal (was useful in my automation, I can remove on request)