### PR TITLE
fix: use local_rank for set_device, broadcast run_dir, feat: add cosine scheduler

### DIFF
--- a/train.py
+++ b/train.py
@@ -293,7 +293,7 @@ if __name__ == '__main__':
     deepspeed.init_distributed()
 
     # needed for broadcasting Queue in dataset.py
-    torch.cuda.set_device(dist.get_rank())
+    torch.cuda.set_device(local_rank)
 
     resume_from_checkpoint = (
         args.resume_from_checkpoint if args.resume_from_checkpoint is not None
@@ -509,24 +509,26 @@ if __name__ == '__main__':
     else:
         is_adapter = False
 
-    # if this is a new run, create a new dir for it
+    # Determine run_dir on rank 0 and broadcast it
+    run_dir_container = [None]
+    if is_main_process():
+        if resume_from_checkpoint is True:
+            run_dir_container[0] = get_most_recent_run_dir(config['output_dir'])
+        elif isinstance(resume_from_checkpoint, str):
+            run_dir_container[0] = os.path.join(config['output_dir'], resume_from_checkpoint)
+        else:
+            run_dir_container[0] = os.path.join(config['output_dir'], datetime.now(timezone.utc).strftime('%Y%m%d_%H-%M-%S'))
+    
+    torch.distributed.broadcast_object_list(run_dir_container, src=0, group=dist.get_world_group())
+    run_dir = run_dir_container[0]
+
+    os.makedirs(run_dir, exist_ok=True)
     if not resume_from_checkpoint and is_main_process():
-        run_dir = os.path.join(config['output_dir'], datetime.now(timezone.utc).strftime('%Y%m%d_%H-%M-%S'))
-        os.makedirs(run_dir, exist_ok=True)
         shutil.copy(args.config, run_dir)
         shutil.copy(config['dataset'], run_dir)
         for eval_dataset in config['eval_datasets']:
             shutil.copy(eval_dataset['config'], run_dir)
-    # wait for all processes then get the most recent dir (may have just been created)
     dist.barrier()
-    if resume_from_checkpoint is True:  # No specific folder provided, use most recent
-        run_dir = get_most_recent_run_dir(config['output_dir'])
-    elif isinstance(resume_from_checkpoint, str):  # Specific folder provided
-        run_dir = os.path.join(config['output_dir'], resume_from_checkpoint)
-        if not os.path.exists(run_dir):
-            raise ValueError(f"Checkpoint directory {run_dir} does not exist")
-    else:  # Not resuming, use most recent (newly created) dir
-        run_dir = get_most_recent_run_dir(config['output_dir'])
 
     # WandB logging
     wandb_enable = config.get('monitoring', {}).get('enable_wandb', False)
@@ -787,6 +789,8 @@ if __name__ == '__main__':
         lr_scheduler = torch.optim.lr_scheduler.ConstantLR(optimizer, factor=1.0)
     elif scheduler_type == 'linear':
         lr_scheduler = torch.optim.lr_scheduler.LinearLR(optimizer, start_factor=1.0, end_factor=0.0, total_iters=config['epochs'] * steps_per_epoch)
+    elif scheduler_type == 'cosine':
+        lr_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=config['epochs'] * steps_per_epoch, eta_min=1e-6)
     else:
         raise NotImplementedError(f'Unknown lr_scheduler: {scheduler_type}')
     if config['warmup_steps'] > 0:


### PR DESCRIPTION
# Changes

## 2026-04-09

### Bug fix: `torch.cuda.set_device` uses `local_rank` instead of global rank

In `train.py`, `torch.cuda.set_device` was previously called with `dist.get_rank()`, which returns the **global** rank across all nodes. This is incorrect in multi-node setups where each node has multiple GPUs — the device index must be the **local** rank (i.e., the rank within a single node). Changed to use `local_rank` instead.

### Fix: deterministic `run_dir` broadcast across all ranks

Previously, the training run directory was created by rank 0, and all other ranks would discover it after a `barrier()` via `get_most_recent_run_dir()`. This was fragile in multi-node distributed environments where filesystem timing could cause races or incorrect directory selection.

The new approach:
- Rank 0 determines `run_dir` (whether starting fresh or resuming from checkpoint)
- The path is shared to all ranks via `torch.distributed.broadcast_object_list`
- All ranks call `os.makedirs(run_dir, exist_ok=True)` directly with the exact path

This makes checkpoint resumption more robust and removes the dependency on filesystem ordering.

### Feature: cosine LR scheduler

Added support for `scheduler_type = 'cosine'` in the training config. Uses `torch.optim.lr_scheduler.CosineAnnealingLR` with `eta_min=1e-6`. Annealing period (`T_max`) is set to the total number of training steps (`epochs * steps_per_epoch`).

Example config:
```toml
lr_scheduler = 'cosine'
```
