### PR TITLE
Support multi-control edit datasets

### DIFF
--- a/docs/supported_models.md
+++ b/docs/supported_models.md
@@ -305,6 +305,8 @@ See the [Flux Kontext example dataset config](../examples/flux_kontext_dataset.t
 
 **IMPORTANT**: The control/context images should be approximately the same aspect ratio as the target images. All of the aspect ratio and size bucketing is done with respect to the target images. Then, the control image is resized and cropped to match the target image size. If the aspect ratio of the control image is very different from the target image, it will be cropping away a lot of the control image.
 
+For models that support multiple reference images per target, use ```control_paths``` instead of ```control_path```. Each directory in the list must contain files with stems matching the target images, and the images are passed to the model in list order.
+
 Flux Kontext LoRAs are saved in Diffusers format, which will work in ComfyUI.
 
 ## Wan2.2

--- a/examples/flux_kontext_dataset.toml
+++ b/examples/flux_kontext_dataset.toml
@@ -13,6 +13,12 @@ path = '/home/anon/data/images/kontext/target'
 # The control/context images go in here, with the same name as the corresponding target images.
 # Every target image must have a corresponding control image or it will fail.
 control_path = '/home/anon/data/images/kontext/control'
+# For multi-image edit models, use control_paths instead. Every listed directory must
+# contain one matching control image for each target image.
+# control_paths = [
+#     '/home/anon/data/images/kontext/person_ref',
+#     '/home/anon/data/images/kontext/style_ref',
+# ]
 
 # You can train on normal t2i datasets at the same time. But they have to be in a different directory.
 

--- a/models/flux2.py
+++ b/models/flux2.py
@@ -93,10 +93,15 @@ class Flux2Pipeline(ComfyPipeline):
             elif len(args) == 2:
                 # Control image provided (for reference conditioning)
                 tensor, control_tensor = args
-                # Encode both using parent's method
                 result = parent_vae_fn(tensor)
-                control_result = parent_vae_fn(control_tensor)
-                result['control_latents'] = control_result['latents']
+                if control_tensor.ndim == tensor.ndim + 1:
+                    bs, num_controls = control_tensor.shape[:2]
+                    control_tensor = control_tensor.flatten(0, 1)
+                    control_result = parent_vae_fn(control_tensor)
+                    result['control_latents'] = control_result['latents'].unflatten(0, (bs, num_controls))
+                else:
+                    control_result = parent_vae_fn(control_tensor)
+                    result['control_latents'] = control_result['latents']
                 return result
             else:
                 raise RuntimeError(f'Unexpected number of args: {len(args)}')
@@ -173,10 +178,19 @@ class Flux2Pipeline(ComfyPipeline):
         extra_inputs = ()
         if 'control_latents' in inputs:
             control_latents = inputs['control_latents'].float()
-            control_latents = self.model_patcher.model.process_latent_in(control_latents)
-            assert control_latents.shape == latents.shape, (
-                f"Control latents shape {control_latents.shape} doesn't match latents shape {latents.shape}"
-            )
+            if control_latents.ndim == latents.ndim + 1:
+                control_latents = torch.stack([
+                    self.model_patcher.model.process_latent_in(control_latents[:, i])
+                    for i in range(control_latents.shape[1])
+                ], dim=1)
+                assert control_latents.shape[0] == bs and control_latents.shape[2:] == latents.shape[1:], (
+                    f"Control latents shape {control_latents.shape} doesn't match latents shape {latents.shape}"
+                )
+            else:
+                control_latents = self.model_patcher.model.process_latent_in(control_latents)
+                assert control_latents.shape == latents.shape, (
+                    f"Control latents shape {control_latents.shape} doesn't match latents shape {latents.shape}"
+                )
             extra_inputs = (control_latents,)
 
         return (noisy_latents, t, *conds) + extra_inputs, (target, mask)
@@ -266,13 +280,21 @@ class InitialLayer(nn.Module):
         img, img_ids = self.process_img(x)
 
         # Process control latents if present
+        control_imgs = []
+        control_img_ids = []
         if has_control:
             control_latents = extra[0]
-            control_img, control_img_ids = self.process_img(control_latents, index=self.params.ref_index_scale)
-            control_img_len = control_img.shape[1]
-            assert control_img_len == img.shape[1], (
-                f"Control image sequence length {control_img_len} doesn't match noisy image {img.shape[1]}"
-            )
+            if control_latents.ndim == x.ndim:
+                control_latents = control_latents.unsqueeze(1)
+            for i in range(control_latents.shape[1]):
+                index = self.params.ref_index_scale * (i + 1)
+                control_img, control_ids = self.process_img(control_latents[:, i], index=index)
+                control_img_len = control_img.shape[1]
+                assert control_img_len == img.shape[1], (
+                    f"Control image sequence length {control_img_len} doesn't match noisy image {img.shape[1]}"
+                )
+                control_imgs.append(control_img)
+                control_img_ids.append(control_ids)
 
         img_len = torch.tensor(img.shape[1], dtype=torch.int64, device=device)
 
@@ -284,13 +306,11 @@ class InitialLayer(nn.Module):
 
         img = self.img_in(img)
 
-        # Process control image with same img_in projection if present
+        # Process control images with same img_in projection if present
         if has_control:
-            control_img = self.img_in(control_img)
-            # Concatenate noisy image and control image along sequence dimension
-            img = torch.cat([img, control_img], dim=1)
-            # Update img_ids to include control image positions
-            img_ids = torch.cat([img_ids, control_img_ids], dim=1)
+            control_imgs = [self.img_in(control_img) for control_img in control_imgs]
+            img = torch.cat([img, *control_imgs], dim=1)
+            img_ids = torch.cat([img_ids, *control_img_ids], dim=1)
         vec = self.time_in(timestep_embedding(timesteps, 256).to(img.dtype))
         if self.params.guidance_embed:
             if guidance is not None:

--- a/models/qwen_image.py
+++ b/models/qwen_image.py
@@ -301,9 +301,16 @@ class QwenImagePipeline(BasePipeline):
             result = {'latents': latents}
             if len(args) == 2:
                 control_image = args[1]
-                control_latents = vae.encode(control_image.to(vae.device, vae.dtype)).latent_dist.mode()
-                control_latents = (control_latents - vae.latents_mean_tensor) / vae.latents_std_tensor
-                result['control_latents'] = control_latents
+                if control_image.ndim == image.ndim + 1:
+                    bs, num_controls = control_image.shape[:2]
+                    control_image = control_image.flatten(0, 1)
+                    control_latents = vae.encode(control_image.to(vae.device, vae.dtype)).latent_dist.mode()
+                    control_latents = (control_latents - vae.latents_mean_tensor) / vae.latents_std_tensor
+                    result['control_latents'] = control_latents.unflatten(0, (bs, num_controls))
+                else:
+                    control_latents = vae.encode(control_image.to(vae.device, vae.dtype)).latent_dist.mode()
+                    control_latents = (control_latents - vae.latents_mean_tensor) / vae.latents_std_tensor
+                    result['control_latents'] = control_latents
             return result
         return fn
 
@@ -351,13 +358,31 @@ class QwenImagePipeline(BasePipeline):
                 output_hidden_states=True,
             )
         else:
-            template = self.prompt_template_encode_edit
             drop_idx = self.prompt_template_encode_start_idx_edit
-            txt = [template.format(e) for e in prompt]
-            images = [
-                self.load_image_for_vlm(file)
-                for file in control_files
-            ]
+            if len(control_files) > 0 and isinstance(control_files[0], (list, tuple)):
+                control_files_per_prompt = control_files
+            else:
+                control_files_per_prompt = [[file] for file in control_files]
+            assert len(control_files_per_prompt) == len(prompt), (len(control_files_per_prompt), len(prompt))
+            if all(len(files) == 1 for files in control_files_per_prompt):
+                txt = [self.prompt_template_encode_edit.format(e) for e in prompt]
+                images = [
+                    self.load_image_for_vlm(files[0])
+                    for files in control_files_per_prompt
+                ]
+            else:
+                vision_tokens = [
+                    ''.join('<|vision_start|><|image_pad|><|vision_end|>' for _ in files)
+                    for files in control_files_per_prompt
+                ]
+                txt = [
+                    self.prompt_template_encode_edit.replace('<|vision_start|><|image_pad|><|vision_end|>', vision_token).format(e)
+                    for e, vision_token in zip(prompt, vision_tokens)
+                ]
+                images = [
+                    [self.load_image_for_vlm(file) for file in files]
+                    for files in control_files_per_prompt
+                ]
             model_inputs = self.processor(
                 text=txt,
                 images=images,
@@ -454,12 +479,21 @@ class QwenImagePipeline(BasePipeline):
 
         if 'control_latents' in inputs:
             control_latents = inputs['control_latents'].float()
-            control_latents = self._pack_latents(control_latents, bs, num_channels_latents, h, w)
-            assert control_latents.shape == latents.shape, (control_latents.shape, latents.shape)
+            if control_latents.ndim == latents.ndim:
+                control_latents = control_latents.unsqueeze(1)
+            assert control_latents.shape[0] == bs and control_latents.shape[2:] == inputs['latents'].shape[1:], (
+                control_latents.shape, inputs['latents'].shape
+            )
+            packed_control_latents = [
+                self._pack_latents(control_latents[:, i], bs, num_channels_latents, h, w)
+                for i in range(control_latents.shape[1])
+            ]
+            for control_latents_i in packed_control_latents:
+                assert control_latents_i.shape == latents.shape, (control_latents_i.shape, latents.shape)
             img_seq_len = torch.tensor(x_t.shape[1], device=x_t.device).repeat((bs,))
             extra = (img_seq_len,)
-            x_t = torch.cat([x_t, control_latents], dim=1)
-            img_shapes.append((1, h // 2, w // 2))
+            x_t = torch.cat([x_t, *packed_control_latents], dim=1)
+            img_shapes.extend([(1, h // 2, w // 2)] * len(packed_control_latents))
         else:
             extra = tuple()
 

--- a/utils/dataset.py
+++ b/utils/dataset.py
@@ -476,6 +476,12 @@ class DirectoryDataset:
         self.path = Path(self.directory_config['path'])
         self.mask_path = Path(self.directory_config['mask_path']) if 'mask_path' in self.directory_config else None
         self.control_path = Path(self.directory_config['control_path']) if 'control_path' in self.directory_config else None
+        if self.control_path is not None and 'control_paths' in self.directory_config:
+            raise RuntimeError('control_path and control_paths are mutually exclusive')
+        control_paths = self.directory_config.get('control_paths', [])
+        if isinstance(control_paths, str):
+            raise RuntimeError('control_paths must be a list of directories, not a string')
+        self.control_paths = [Path(path) for path in control_paths]
         # For testing. Default if a mask is missing.
         self.default_mask_file = Path(self.directory_config['default_mask_file']) if 'default_mask_file' in self.directory_config else None
         self.cache_dir = self.path / 'cache' / self.model_name
@@ -488,6 +494,9 @@ class DirectoryDataset:
             raise RuntimeError(f'Invalid mask_path: {self.mask_path}')
         if self.control_path is not None and (not self.control_path.exists() or not self.control_path.is_dir()):
             raise RuntimeError(f'Invalid control_path: {self.control_path}')
+        for control_path in self.control_paths:
+            if not control_path.exists() or not control_path.is_dir():
+                raise RuntimeError(f'Invalid control_paths entry: {control_path}')
         if self.default_mask_file is not None and (not self.default_mask_file.exists() or not self.default_mask_file.is_file()):
             raise RuntimeError(f'Invalid default_mask_file: {self.default_mask_file}')
 
@@ -631,6 +640,10 @@ class DirectoryDataset:
             # Mask can have any extension, it just needs to have the same stem as the image.
             mask_file_stems = {path.stem: path for path in self.mask_path.glob('*') if path.is_file()} if self.mask_path is not None else {}
             control_file_stems = {path.stem: path for path in self.control_path.glob('*') if path.is_file()} if self.control_path is not None else {}
+            control_file_stems_list = [
+                {path.stem: path for path in control_path.glob('*') if path.is_file()}
+                for control_path in self.control_paths
+            ]
 
             def process_file(file):
                 if file.suffix != '.tar':
@@ -669,10 +682,17 @@ class DirectoryDataset:
                         if image_file.stem not in control_file_stems:
                             raise RuntimeError(f'No control file exists for image {image_file}')
                         control_files.append(str(control_file_stems[image_file.stem]))
+                    elif self.control_paths:
+                        control_files_for_image = []
+                        for control_path, stems in zip(self.control_paths, control_file_stems_list):
+                            if image_file.stem not in stems:
+                                raise RuntimeError(f'No control file exists for image {image_file} in {control_path}')
+                            control_files_for_image.append(str(stems[image_file.stem]))
+                        control_files.append(control_files_for_image)
             assert len(image_specs) > 0, f'Directory {self.path} had no images/videos!'
 
             d = {'image_spec': image_specs, 'caption_file': caption_files, 'mask_file': mask_files}
-            if self.control_path:
+            if self.control_path or self.control_paths:
                 d['control_file'] = control_files
             metadata_dataset = datasets.Dataset.from_dict(d)
 
@@ -760,7 +780,7 @@ class DirectoryDataset:
             if self.directory_config['shuffle_tags'] and self.shuffle == 0: # backwards compatibility
                 self.shuffle = 1
             captions = shuffle_captions(captions, self.shuffle, self.shuffle_delimiter, self.directory_config['caption_prefix'])
-            if self.control_path:
+            if self.control_path or self.control_paths:
                 empty_return['control_file'] = []
 
             if image_spec[0] is None:
@@ -828,7 +848,7 @@ class DirectoryDataset:
                 'size_bucket': [size_bucket],
                 'is_video': [is_video],
             }
-            if self.control_path:
+            if self.control_path or self.control_paths:
                 ret['control_file'] = [example['control_file'][0]]
             return ret
 
@@ -1076,10 +1096,17 @@ def _cache_fn(datasets, queue, preprocess_media_file_fn, num_text_encoders, rege
             captions.extend([caption] * len(items))
             if is_edit_dataset:
                 control_file = example['control_file'][i]
-                control_items = preprocess_media_file_fn((None, control_file), None, size_bucket)
-                assert len(control_items) == 1
+                control_files = control_file if isinstance(control_file, list) else [control_file]
+                control_tensors = []
+                for file in control_files:
+                    control_items = preprocess_media_file_fn((None, file), None, size_bucket)
+                    assert len(control_items) == 1
+                    control_tensors.append(control_items[0][0])
                 assert len(items) == 1
-                control_tensors_and_masks.append(control_items[0])
+                if len(control_tensors) == 1:
+                    control_tensors_and_masks.append(control_tensors[0])
+                else:
+                    control_tensors_and_masks.append(torch.stack(control_tensors))
             else:
                 control_tensors_and_masks.append(None)
 
@@ -1091,7 +1118,7 @@ def _cache_fn(datasets, queue, preprocess_media_file_fn, num_text_encoders, rege
         results = defaultdict(list)
         for i in range(0, len(tensors_and_masks), caching_batch_size):
             tensor = torch.stack([t[0] for t in tensors_and_masks[i:i+caching_batch_size]])
-            c_tensor = torch.stack([t[0] for t in control_tensors_and_masks[i:i+caching_batch_size]]) if is_edit_dataset else None
+            c_tensor = torch.stack(control_tensors_and_masks[i:i+caching_batch_size]) if is_edit_dataset else None
             if rank not in pipes:
                 pipes[rank] = mp.Pipe(duplex=False)
             parent_conn, child_conn = pipes[rank]


### PR DESCRIPTION
## Summary

Adds support for multi-control edit datasets by allowing a dataset directory to specify multiple control image directories via `control_paths`.

This enables training edit models where each target sample is conditioned on more than one reference/control image, while preserving the existing single-control `control_path` behavior.

## Changes

- Add `control_paths = [...]` support to directory dataset configs.
- Validate that `control_path` and `control_paths` are mutually exclusive.
- Store and cache multi-control tensors with shape `[batch, num_controls, ...]`.
- Update Flux2 edit training to encode and consume multiple control images.
- Update Qwen-Image edit training and prompt processing to support multiple VLM/control images.
- Document multi-control support and add an example config snippet.

## Example

```toml
[[directory]]
path = '/path/to/targets'
control_paths = [
  '/path/to/control_00',
  '/path/to/control_01',
]