### PR TITLE
Fix MiniMax H3 pipeline-parallel training with grad accumulation and mixed-audio data

### DIFF
--- a/models/minimax_h3.py
+++ b/models/minimax_h3.py
@@ -419,6 +419,10 @@ class MinimaxH3Pipeline(ComfyPipeline):
             output, audio_output = outputs
             target, audio_target, mask = label
             video_loss = single_loss(output, target, mask=mask)
+            # audio_target may be padded to match another example's audio length from the same
+            # gradient-accumulation group (see MinimaxH3Pipeline.prepare_inputs); audio_output's
+            # length is authoritative since the model derives it from this example's own valid_audio flag.
+            audio_target = audio_target[..., :audio_output.shape[-1]]
             audio_loss = single_loss(audio_output, audio_target)
             # make each token count the same for loss, regardless of modality
             # TODO: what is the best thing to do here? configurable audio loss scale?

--- a/train.py
+++ b/train.py
@@ -611,6 +611,7 @@ if __name__ == '__main__':
         partition_method=partition_method,
         manual_partition_split=partition_split,
         loss_fn=model.get_loss_fn(),
+        dynamic_shape=True,
         **additional_pipeline_module_kwargs
     )
     model.pipeline_model = pipeline_model

--- a/utils/dataset.py
+++ b/utils/dataset.py
@@ -1009,7 +1009,7 @@ class Dataset:
             features = [example[key] for example in examples]
             if torch.is_tensor(features[0]):
                 shape = features[0].shape
-                if all(f.shape == shape for f in features):
+                if all(torch.is_tensor(f) and f.shape == shape for f in features):
                     # if we can form a single batched tensor, do it
                     features = torch.stack(features)
             ret[key] = features


### PR DESCRIPTION
## Summary

Three separate bugs, all exposed by the same configuration: `pipeline_stages > 1` combined with `gradient_accumulation_steps > 1`, training on data where some examples have an audio track and some don't. Each bug was found and fixed in turn by reproducing the failure, patching it, and rerunning.

1. **`utils/dataset.py` (`Dataset._collate`)**: the generic collate path assumed that if the first example in a batch group had a tensor for a given field, every example in the group did too. `audio_latents` is `None` for clips with no audio track, so grouping a with-audio clip next to a without-audio clip crashed with `AttributeError: 'NoneType' object has no attribute 'shape'` while checking `f.shape` on a `None` entry. The `mask` field already had special handling for this exact "some examples have it, some don't" case a few lines below; `audio_latents` (and any other field with the same pattern) just needed the tensor-batching check to require every entry actually be a tensor before comparing shapes, falling back to a plain list otherwise — which is the form downstream code already expects.

2. **`models/minimax_h3.py` (`MinimaxH3Pipeline.prepare_inputs` / `loss_fn`)**: `prepare_inputs` batches audio latents across the whole gradient-accumulation group before the group is split into individual microbatches, sizing the shared audio tensor from whichever example in the group happens to have valid audio. A microbatch whose own clip has no audio therefore inherited its sibling's audio length in the loss target, while the model correctly produces a zero-length audio output for that microbatch (it decides audio length per-example from that example's own `valid_audio` flag). The mismatch surfaced as `RuntimeError: The size of tensor a (0) must match the size of tensor b (N)` in the audio MSE loss. `loss_fn` now trims `audio_target` to `audio_output`'s length, since the model's own output length is authoritative per example — a no-audio example now correctly ends up with a 0-length target and output on both sides, which the existing `audio_tokens > 0` guard already handles.

3. **`train.py` (pipeline module construction)**: pass `dynamic_shape=True` to the DeepSpeed `PipelineModule`. With `gradient_accumulation_steps > 1`, DeepSpeed's default behavior sends pipeline activation-tensor shape metadata across GPU stage boundaries only once per training step and reuses those cached shapes/buffers for every microbatch after that. MiniMax H3's packed sequence length varies per example depending on audio presence, so microbatches with a genuinely different real shape than the first one in the step were transferred using stale metadata. `dynamic_shape=True` is DeepSpeed's documented mechanism for handling activation shapes that vary across microbatches (e.g. curriculum learning with changing seqlen); the tradeoff is a small amount of extra overhead re-sending shape metadata and reallocating pipeline buffers every microbatch instead of once per step.

## Test plan

- [x] Reproduced end-to-end on a 2-GPU pipeline-parallel (`pipeline_stages=2`) LoRA training run with `train_micro_batch_size_per_gpu=1` and `gradient_accumulation_steps=2`, against a video dataset where some clips lack an audio track — the configuration needed to trigger all three bugs.
- [x] Hit each failure in sequence, applied the corresponding fix, and reran after each one.
- [x] Training now proceeds past multiple full optimizer steps with the loss decreasing step to step, with no errors from any of the three code paths above.