### PR TITLE
Fix deadlock with pipeline_stages > 2: DeepSpeed recv buffer reuse ignores dtype

### DIFF
--- a/utils/patches.py
+++ b/utils/patches.py
@@ -1,6 +1,8 @@
 from typing import Optional
 import sys
 import os.path
+from functools import reduce
+from operator import mul
 sys.path.insert(0, os.path.join(os.path.abspath(os.path.dirname(__file__)), '../submodules/HunyuanVideo'))
 sys.path.insert(0, os.path.join(os.path.abspath(os.path.dirname(__file__)), '../submodules/ComfyUI'))
 
@@ -11,6 +13,7 @@ import peft
 from peft.tuners._buffer_dict import BufferDict
 from transformers import CLIPTextModel, AutoModel
 import deepspeed
+from deepspeed.runtime.pipe.engine import PipelineEngine
 from deepspeed.runtime.pipe.schedule import (
     SendGrad, RecvActivation, SendActivation, RecvGrad, LoadMicroBatch, ForwardPass, BackwardPass,
     ReduceTiedGrads, ReduceGrads, OptimizerStep,
@@ -158,6 +161,29 @@ def train_schedule_steps(self):
         # Prepare state for next time
         prev_micro_batch_id = micro_batch_id
         yield cmds
+
+
+def _allocate_or_extend_buffers(self, idx, shape, dtype):
+    # Upstream DeepSpeed reuses pooled recv buffers by numel only and ignores the requested dtype.
+    # The pool is shared between activation recvs (which for some models include int64 tensors, e.g.
+    # flux2's txt_len/img_len/hw) and grad recvs (float only). With pipeline_stages > 2, a middle
+    # stage performs both kinds of recvs: the grad recv reallocates the int64 slots as large float
+    # buffers, and every following activation recv (dynamic_shape re-queries the pool each micro-batch)
+    # gets a float view for the int64 tensors. The corrupted dtypes propagate downstream via the send
+    # meta, the is_floating_point() filter in _exec_recv_grads/_exec_send_grads then disagrees about
+    # how many grad tensors to transfer, and the order-matched p2p send/recvs deadlock permanently.
+    # Fix: also reallocate when the dtype differs.
+    numel = reduce(mul, shape) if len(shape) > 0 else 1
+    if (len(self._grad_layer_buf) <= idx or self._grad_layer_buf[idx].numel() < numel
+            or self._grad_layer_buf[idx].dtype != dtype):
+        new_buf = self._allocate_buffer(shape, dtype=dtype, num_buffers=1)[0]
+        if len(self._grad_layer_buf) <= idx:
+            self._grad_layer_buf.append(new_buf)
+        else:
+            self._grad_layer_buf[idx] = new_buf
+        return self._grad_layer_buf[idx]
+    else:
+        return self._grad_layer_buf[idx].flatten()[:numel].view(shape)
 
 
 def broadcast_model(self):
@@ -427,6 +453,11 @@ def apply_patches():
 
     # Don't fail if there are no trainable parameters on a stage.
     deepspeed.runtime.engine.DeepSpeedEngine.clip_fp32_gradients = lambda self: clip_grad_norm_(parameters=self.module.parameters(), max_norm=self.gradient_clipping(), mpu=self.mpu)
+
+    # Fix pipeline_stages > 2 hanging before the first step (#511): the pooled recv buffers must be
+    # reallocated when the requested dtype differs, otherwise int64 tensors in the inter-stage tuple
+    # get corrupted to float on middle stages and the grad send/recv counts diverge -> NCCL deadlock.
+    PipelineEngine._allocate_or_extend_buffers = _allocate_or_extend_buffers
 
     # Efficiently send Tensors across Queues and Pipes when using the third-party multiprocess library.
     reduction.init_reductions()


### PR DESCRIPTION
### Symptom

With `pipeline_stages >= 3`, training hangs before the first optimizer step; the NCCL watchdog aborts all ranks ~30 min later (`Watchdog caught collective operation timeout ... OpType=RECV`). Reported in #511 (FLUX.2 Klein, pp3). Reproduced with FLUX.2-dev LoRA, pp4, 4x RTX 4090, torch 2.9.1 + deepspeed 0.18.4. `pipeline_stages = 2` is unaffected.

### Root cause

`PipelineEngine._allocate_or_extend_buffers` (deepspeed/runtime/pipe/engine.py) keeps one buffer pool `self._grad_layer_buf`, indexed by tensor position, shared by **activation recvs** (`_recv_tensor_meta`) and **grad recvs** (`_exec_recv_grads`). Its reuse path returns a view of the pooled buffer and silently ignores the requested dtype:

```python
if len(self._grad_layer_buf) <= idx or self._grad_layer_buf[idx].numel() < numel:
    new_buf = self._allocate_buffer(shape, dtype=dtype, num_buffers=1)[0]
    ...
else:
    return self._grad_layer_buf[idx].flatten()[:numel].view(shape)  # dtype ignored
```

The flux2 inter-stage tuple `(img, pe, txt_len, img_len, hw, vec_orig, *mod_vecs)` contains three int64 tensors. On a **middle stage** — which only exists when `pipeline_stages >= 3` — the pool serves both kinds of recvs:

1. The first activation recv allocates the slots with correct dtypes (int64 slots are tiny).
2. The first grad recv requests float buffers at the same indices, so the int64 slots are **reallocated as large float buffers**.
3. `dynamic_shape=True` (always set by this repo) re-queries the pool on every activation recv. From the next micro-batch on, the int64 tensors land in those slots via the reuse path and come back as **float views**. The corruption propagates downstream because each stage's send meta re-declares the (now wrong) dtypes.
4. On a corrupted stage `t.is_floating_point()` stops filtering the length tensors: it posts **9** grad recvs while the peer sends **6** grad tensors. DeepSpeed's p2p ops are matched purely by posting order per rank pair, so every subsequent transfer pairs wrong partners with wrong sizes and never completes. All ranks freeze: two in `autograd.backward`, one in `_send_tensor_meta`, the last stage inside the model's final layer waiting on the `hw` tensor it will never receive.

Flight-recorder dumps (`TORCH_NCCL_TRACE_BUFFER_SIZE`) taken at the hang show the mismatch directly:

```
rank1 pending: 6x nccl:recv 1<-2  [1,6902,6144] [1,1,6902,64,2,2] [1,6144] 3x[1,1,6144]
rank2 pending: 9x nccl:recv 2<-3  [1,6902,6144] [1,1,6902,64,2,2] [] [] [2] [1,6144] 3x[1,1,6144]
                                                 ^^^^^^^^ "grad" buffers for int64 txt_len/img_len/hw
```

### Why pipeline_stages = 2 works

Stage 0 only receives grads and the last stage only receives activations — no rank mixes the two kinds in the pool. The bug needs a middle stage plus `dynamic_shape=True` plus non-float tensors in the inter-stage tuple, which is also why standard LLM DeepSpeed setups never hit it.

### Fix

Reallocate when the dtype differs (one added condition), applied as a monkeypatch in `utils/patches.py` like the other DeepSpeed workarounds in this repo. The extra reallocation only affects the tiny int64 slots; large float buffers still reuse.

### Verification

FLUX.2-dev LoRA, RTX 4090 48G, GAS=4, aspect-ratio-bucketed dataset at 1280px:

- before: `pipeline_stages=4` completed 0 steps; all-rank NCCL RECV watchdog abort in 3/3 runs (GAS 4/16, compile on/off)
- after: `pipeline_stages=3` (same topology as #511) on 3x 4090: 25/25 steps, loss 0.35-0.56, steady 27.2 s/step; `pipeline_stages=4` on 4x 4090: 25/25 steps, loss 0.40-0.59, steady 23.7 s/step

Unrelated caveat from debugging: our test box turned out to have two GPUs with degraded PCIe links (stuck at gen1 under load), which produced intermittent nan losses in any multi-GPU run using those cards — including plain `pipeline_stages=2` without this patch. If you see nan after this fix, check `nvidia-smi --query-gpu=pcie.link.gen.current --format=csv` under load before blaming the software.

Fixes #511

