### PR TITLE
Fix attn_bias alignment crash in MiniMax H3 under torch.compile

### DIFF
--- a/models/minimax_h3.py
+++ b/models/minimax_h3.py
@@ -71,13 +71,16 @@ def _pad_attn_bias_for_sdpa(mask, q):
     # torch's memory-efficient SDPA backend (aten._efficient_attention_forward) requires
     # attn_bias.stride(1) to be a multiple of 8. Our packed sequence length is arbitrary, so
     # force alignment by allocating the mask's storage with the key dim padded, then handing
-    # back a narrowed view with the original (unpadded) logical shape.
+    # back a narrowed view with the original (unpadded) logical shape. Keep the mask's other
+    # dims (e.g. a broadcastable query dim of 1) untouched -- materializing them against q's
+    # full sequence length here would blow up memory to O(seq_len^2) for long video sequences.
     nk = mask.shape[-1]
     pad = (-nk) % 8
-    nq = q.shape[-2]
-    buf = torch.zeros((mask.shape[0], mask.shape[1], nq, nk + pad), dtype=mask.dtype, device=mask.device)
+    if pad == 0:
+        return mask
+    buf = torch.zeros(*mask.shape[:-1], nk + pad, dtype=mask.dtype, device=mask.device)
     buf[..., :nk] = mask
-    return buf[..., :nk].expand(q.shape[0], q.shape[1], -1, -1)
+    return buf[..., :nk]
 
 
 class Attention(nn.Module):
@@ -91,6 +94,7 @@ class Attention(nn.Module):
         self.k_norm = operations.RMSNorm(head_dim, eps=eps, dtype=dtype, device=device)
         self.out_proj = operations.Linear(inner, hidden, bias=False, dtype=dtype, device=device)
 
+    @torch.compiler.disable
     def forward(self, x, rope_freqs=None, attention_mask=None, transformer_options={}):
         b, s = x.shape[:2]
         q, k, v = self.qkv_proj(x).split(self.heads * self.head_dim, dim=-1)

--- a/models/minimax_h3.py
+++ b/models/minimax_h3.py
@@ -67,6 +67,19 @@ comfy.ldm.minimax.model._mod_scale_shift = _mod_scale_shift
 comfy.ldm.minimax.model._mod_gate = _mod_gate
 
 
+def _pad_attn_bias_for_sdpa(mask, q):
+    # torch's memory-efficient SDPA backend (aten._efficient_attention_forward) requires
+    # attn_bias.stride(1) to be a multiple of 8. Our packed sequence length is arbitrary, so
+    # force alignment by allocating the mask's storage with the key dim padded, then handing
+    # back a narrowed view with the original (unpadded) logical shape.
+    nk = mask.shape[-1]
+    pad = (-nk) % 8
+    nq = q.shape[-2]
+    buf = torch.zeros((mask.shape[0], mask.shape[1], nq, nk + pad), dtype=mask.dtype, device=mask.device)
+    buf[..., :nk] = mask
+    return buf[..., :nk].expand(q.shape[0], q.shape[1], -1, -1)
+
+
 class Attention(nn.Module):
     def __init__(self, hidden, heads, head_dim, eps, dtype=None, device=None, operations=None):
         super().__init__()
@@ -97,6 +110,8 @@ class Attention(nn.Module):
         q = q.transpose(1, 2)
         k = k.transpose(1, 2)
         v = v.transpose(1, 2)
+        if attention_mask is not None:
+            attention_mask = _pad_attn_bias_for_sdpa(attention_mask, q)
         out = optimized_attention(q, k, v, self.heads, mask=attention_mask, skip_reshape=True, transformer_options=transformer_options)
         return self.out_proj(out)
 


### PR DESCRIPTION
## Summary
- Fixes a crash in MiniMax H3 training when `compile = true`: `RuntimeError: attn_bias is not correctly aligned (strideH)`.
- PyTorch's memory-efficient SDPA backend (`aten._efficient_attention_forward`) requires the attention bias's key-dim stride to be a multiple of 8. Eager execution handles this transparently, but `torch.compile`/Inductor lowers directly to the aten op and enforces the check strictly, so packed sequences whose length isn't 8-aligned crash on the first compiled forward pass.
- `models/minimax_h3.py`'s `Attention.forward` now pads the mask's underlying storage to an 8-aligned key dimension and returns a narrowed view with the original logical shape before calling `optimized_attention`, mirroring the pad-then-narrow trick already used by `attention_xformers` in the vendored ComfyUI attention code.

## Follow-up commit
The initial fix built the padded buffer using the query's full sequence length instead of the mask's own (broadcastable) query dimension, turning a cheap `(batch,1,1,seq)` bias into a dense `(batch,heads,seq,seq)` allocation. This was invisible for images (short sequences) but caused massive VRAM spikes (tens of GB in a single allocation) for video training. The second commit:
- Preserves the mask's original shape, only padding the last dimension's storage so its stride stays 8-aligned, and skips the allocation entirely when no padding is needed.
- Adds `@torch.compiler.disable` to `Attention.forward` (matching the existing pattern already used on `InitialLayer`/`FinalLayer`), because `torch.compile`/Inductor's lowering of `aten._efficient_attention_forward` always materializes the bias to the full `(batch,heads,seq,seq)` shape regardless of broadcast strides — confirmed by inspecting the generated Inductor kernel, which allocated a dense `(1, heads, seq, seq)` buffer and broadcast-copied the small mask into it before the attention call. Disabling compile for just this method keeps it running eagerly (where the broadcastable bias is never densified) while the rest of the transformer block (qkv projection, RMSNorm, SwiGLU MLP) still compiles.

## Test plan
- [x] Ran full MiniMax H3 pipeline-parallel training (3 GPUs, `compile = true`) to completion (1001 steps) with the initial fix; previously crashed on step 1 with the `attn_bias` alignment error.
- [x] Reproduced the O(seq_len^2) VRAM blowup on video training (crash asking to allocate 86+ GiB), confirmed root cause by inspecting the generated Inductor kernel, applied the follow-up fix, and confirmed training runs with normal VRAM usage under `compile = true` on video data.